### PR TITLE
Extending sleep time after BigCouch restart

### DIFF
--- a/ansible/roles/dbnode/handlers/main.yml
+++ b/ansible/roles/dbnode/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 
 - name: restart bigcouch
-  shell: sleep 5; sv restart bigcouch && sleep 5
+  shell: sleep 5; sv restart bigcouch && sleep 10


### PR DESCRIPTION
BigCouch didn't reliably come up before the next task ran, leading the playbook to fail. This extends the sleep time to 10 seconds, which seems to work consistently.
