### PR TITLE
Add contentqa

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,3 @@
+staging
+production
+contentqa

--- a/ansible/contentqa_all.yml
+++ b/ansible/contentqa_all.yml
@@ -1,0 +1,47 @@
+---
+
+- name: Common
+  hosts: all
+  sudo: yes
+  roles:
+    - common
+  vars_files:
+    - ["vars/contentqa.yml", "vars/defaults.yml"]
+
+- name: HTTP proxy
+  hosts: contentqa_proxy_host
+  sudo: yes
+  roles:
+    - contentqa_proxy
+  vars_files:
+    - ["vars/contentqa.yml", "vars/defaults.yml"]
+
+- name: Mail
+  hosts: all
+  sudo: yes
+  roles:
+    - aws_postfix
+  vars_files:
+    - ["vars/contentqa.yml", "vars/defaults.yml"]
+
+- include: playbooks/dbnodes.yml level=contentqa
+
+- include: playbooks/elasticsearch.yml level=contentqa
+
+- include: playbooks/contentqa_webapps.yml level=contentqa
+
+- hosts: api
+  sudo: yes
+  tasks:
+    - name: Ensure existence of QA API account
+      # This could fail if you try to run a "contentqa" VirtualBox VM, because mail
+      # will probably not be set up.
+      ignore_errors: yes
+      uri: >
+          url=http://{{ ansible_hostname }}:{{ api_app_port }}/v2/api_key/aa22-qa-app@dp.la
+          method=POST
+      tags:
+        - api
+        - api_auth
+  vars_files:
+    - ["vars/contentqa.yml", "vars/defaults.yml"]

--- a/ansible/group_vars/all.dist
+++ b/ansible/group_vars/all.dist
@@ -15,3 +15,10 @@ iana_timezone: US/Eastern
 # with a GitHub account that has access to private repositories.  This defaults
 # to ~/.ssh/id_rsa
 # github_private_key_path: ~/.ssh/id_rsa
+
+## The following variables are only relevant if you're using Amazon SES for mail
+# ses_user: CHANGEME
+# ses_password: CHANGEME
+
+## Likewise, this is only relevant if you're using the aws_postfix role:
+# smtp_relayhost_and_port: smtp.example.com:25

--- a/ansible/playbooks/contentqa_webapps.yml
+++ b/ansible/playbooks/contentqa_webapps.yml
@@ -1,0 +1,19 @@
+---
+
+- include: postgresql.yml
+
+- include: mysql.yml
+
+- include: memcached.yml
+
+- name: Common httpd configuration
+  hosts: webapps
+  sudo: yes
+  roles:
+    - common_web
+  vars:
+    level: production
+  vars_files:
+    - ["../vars/{{ level }}.yml", "../vars/defaults.yml"]
+
+- include: api.yml

--- a/ansible/playbooks/deploy_api_contentqa.yml
+++ b/ansible/playbooks/deploy_api_contentqa.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Deploy API (content QA)
+  hosts: api
+  sudo: yes
+  tasks:
+    - include: ../roles/api/tasks/deploy.yml
+  handlers:
+    - include: ../roles/api/handlers/main.yml
+  vars:
+    level: contentqa
+  vars_files:
+    - "../vars/contentqa.yml"
+    - "../roles/api/defaults/main.yml"
+    - "../roles/api/vars/contentqa.yml"

--- a/ansible/roles/api/templates/dpla.yml.j2
+++ b/ansible/roles/api/templates/dpla.yml.j2
@@ -69,9 +69,13 @@ caching:
   cache_results: true
   store: dalli_store
   memcache_servers:
+{% if level != "contentqa" %}
 {% for h in groups['memcached'] %}
     - {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}
 {% endfor %}
+{% else %}
+    - {{ hostvars[ansible_hostname][internal_network_interface]['ipv4']['address'] }}
+    {% endif %}
 
 field_boosts:
   item:

--- a/ansible/roles/api/vars/.gitignore
+++ b/ansible/roles/api/vars/.gitignore
@@ -1,3 +1,4 @@
 development.yml
 staging.yml
 production.yml
+contentqa.yml

--- a/ansible/roles/aws_postfix/handlers/main.yml
+++ b/ansible/roles/aws_postfix/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: restart postfix
+  service: name=postfix state=restarted

--- a/ansible/roles/aws_postfix/tasks/main.yml
+++ b/ansible/roles/aws_postfix/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+
+- name: Ensure that mail packages are installed
+  apt: >
+      name="{{ item }}" state=present
+  with_items:
+    - postfix
+    - mailutils
+  tags:
+    - postfix
+    - mail
+
+- name: Ensure state of postfix configuration file
+  template: >
+      src=main.cf.j2 dest=/etc/postfix/main.cf mode=0644
+  notify: restart postfix
+  tags:
+    - postfix
+    - mail
+
+- name: Ensure state of SASL credentials file
+  template: >
+      src=sasl_passwd.j2 dest=/etc/postfix/sasl_passwd mode=0600
+  notify: restart postfix
+  tags:
+    - postfix
+    - mail
+
+- name: Build SASL credentials database
+  command: postmap hash:/etc/postfix/sasl_passwd
+  notify: restart postfix
+  tags:
+    - postfix
+    - mail
+
+- name: Ensure correct ownership and mode of SASL database file
+  file: path=/etc/postfix/sasl_passwd.db owner=root group=root mode=0600
+  tags:
+    - postfix
+    - mail

--- a/ansible/roles/aws_postfix/templates/main.cf.j2
+++ b/ansible/roles/aws_postfix/templates/main.cf.j2
@@ -1,0 +1,49 @@
+# See /usr/share/postfix/main.cf.dist for a commented, more complete version
+
+
+# Debian specific:  Specifying a file name will cause the first
+# line of that file to be used as the name.  The Debian default
+# is /etc/mailname.
+#myorigin = /etc/mailname
+
+smtpd_banner = $myhostname ESMTP $mail_name (Ubuntu)
+biff = no
+
+# appending .domain is the MUA's job.
+append_dot_mydomain = no
+
+# Uncomment the next line to generate "delayed mail" warnings
+#delay_warning_time = 4h
+
+readme_directory = no
+
+# TLS parameters
+smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+smtpd_use_tls=yes
+smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+
+# See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
+# information on enabling SSL in the smtp client.
+
+myhostname = {{ ansible_hostname }}
+alias_maps = hash:/etc/aliases
+alias_database = hash:/etc/aliases
+mydestination = localdomain, localhost, localhost.localdomain, localhost, {{ ansible_hostname }}
+relayhost = {{ smtp_relayhost_and_port }}
+mailbox_size_limit = 0
+recipient_delimiter = +
+inet_interfaces = all
+default_transport = smtp
+relay_transport = smtp
+inet_protocols = ipv4
+mynetworks = 127.0.0.0/8
+smtp_sasl_auth_enable = yes
+smtp_sasl_security_options = noanonymous
+smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_use_tls = yes
+smtp_tls_security_level = encrypt
+smtp_tls_note_starttls_offer = yes
+
+smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt

--- a/ansible/roles/aws_postfix/templates/sasl_passwd.j2
+++ b/ansible/roles/aws_postfix/templates/sasl_passwd.j2
@@ -1,0 +1,1 @@
+{{ smtp_relayhost_and_port }} {{ ses_user }}:{{ ses_password }}

--- a/ansible/roles/common/files/etc_default_locale
+++ b/ansible/roles/common/files/etc_default_locale
@@ -1,0 +1,1 @@
+LANG="en_US.UTF-8"

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -33,6 +33,12 @@
     - packages
     - time
 
+- name: Ensure correct locale
+  file: src=etc_default_locale dest=/etc/default/locale mode=0644
+  tags:
+    - packages
+    - locale
+
 - name: Install packages
   apt: pkg={{ item }} state=present
   with_items:

--- a/ansible/roles/contentqa_proxy/files/etc_default_haproxy
+++ b/ansible/roles/contentqa_proxy/files/etc_default_haproxy
@@ -1,0 +1,4 @@
+# Set ENABLED to 1 if you want the init script to start haproxy.
+ENABLED=1
+# Add extra flags here.
+#EXTRAOPTS="-de -m 16"

--- a/ansible/roles/contentqa_proxy/files/etc_logrotate.d_haproxy
+++ b/ansible/roles/contentqa_proxy/files/etc_logrotate.d_haproxy
@@ -1,0 +1,13 @@
+/var/log/haproxy*
+{
+    rotate 7
+    daily
+    missingok
+    notifempty
+    compress
+    delaycompress
+    sharedscripts
+    postrotate
+        reload syslog >/dev/null 2>&1 || true
+    endscript
+}

--- a/ansible/roles/contentqa_proxy/files/etc_rsyslog.d_49-haproxy.conf
+++ b/ansible/roles/contentqa_proxy/files/etc_rsyslog.d_49-haproxy.conf
@@ -1,0 +1,6 @@
+$ModLoad imudp
+$UDPServerAddress 127.0.0.1
+$UDPServerRun 514
+
+local1.* -/var/log/haproxy.log
+& ~

--- a/ansible/roles/contentqa_proxy/handlers/main.yml
+++ b/ansible/roles/contentqa_proxy/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: restart haproxy
+  service: name=haproxy state=restarted
+
+- name: restart rsyslog
+  service: name=rsyslog state=restarted

--- a/ansible/roles/contentqa_proxy/tasks/main.yml
+++ b/ansible/roles/contentqa_proxy/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+
+- name: Install packages
+  apt: >
+      pkg="{{ item }}" state=present
+  with_items:
+    - haproxy
+    - hatop
+  tags:
+    - contentqa_proxy
+
+- name: Copy haproxy init defaults file
+  copy: src=etc_default_haproxy dest=/etc/default/haproxy owner=root group=root mode=0644
+  notify: restart haproxy
+  tags:
+    - contentqa_proxy
+
+- name: Update haproxy config file
+  template: src=haproxy.cfg.j2 dest=/etc/haproxy/haproxy.cfg
+  notify: restart haproxy
+  tags:
+    - contentqa_proxy
+
+- name: Configure syslog logging of haproxy messages
+  copy: src=etc_rsyslog.d_49-haproxy.conf dest=/etc/rsyslog.d/49-haproxy.conf mode=0644
+  notify: restart rsyslog
+  tags:
+    - contentqa_proxy
+    - rsyslog
+
+- name: Make sure haproxy logs are rotated
+  copy: src=etc_logrotate.d_haproxy dest=/etc/logrotate.d/haproxy mode=0644
+  tags:
+    - contentqa_proxy
+    - rsyslog

--- a/ansible/roles/contentqa_proxy/templates/haproxy.cfg.j2
+++ b/ansible/roles/contentqa_proxy/templates/haproxy.cfg.j2
@@ -1,0 +1,25 @@
+
+global
+	daemon
+	maxconn 1000
+	log 127.0.0.1 local1 info
+
+defaults
+	mode http
+	log global
+	option httplog
+	option dontlognull
+	option redispatch
+	option forwardfor
+	retries 3
+	timeout connect 5s
+	timeout client 50s
+	timeout server 5m
+
+frontend http-in
+	bind *:80
+	default_backend http-contentqa
+
+backend http-contentqa
+	server {{ ansible_hostname }} {{ hostvars[ansible_hostname][internal_network_interface]['ipv4']['address'] }}:{{ api_app_port }} maxconn 500
+	

--- a/ansible/roles/dbnode/tasks/main.yml
+++ b/ansible/roles/dbnode/tasks/main.yml
@@ -35,11 +35,26 @@
 
 - meta: flush_handlers
 
-- name: Add nodes to cluster
+- name: Add nodes to cluster (not contentqa)
+  # This is the typical case.  There is a group of BigCouch nodes and you want
+  # each node in the inventory file added to the cluster.
   uri: >
       url="http://{{ hostname }}:5986/nodes/{{ dbnode_id_name }}@{{ item }}"
       method=PUT body="{}" status_code="201,409"
   with_items: groups['dbnodes']
+  when: level != "contentqa"
+  tags:
+    - database
+
+- name: Add nodes to cluster (contentqa)
+  # This is a special case for a content QA environment, where there could be
+  # multiple QA hosts, but each one only has a single BigCouch node and you don't
+  # want them talking to each other, even though there are multiple dbnodes in
+  # the inventory.
+  uri: >
+      url="http://{{ ansible_hostname }}:5986/nodes/{{ dbnode_id_name }}@{{ ansible_hostname }}"
+      method=PUT body="{}" status_code="201,409"
+  when: level == "contentqa"
   tags:
     - database
 

--- a/ansible/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -26,7 +26,11 @@
 #
 # cluster.name: elasticsearch
 {% if elasticsearch_cluster_name is defined %}
-cluster.name: {{ elasticsearch_cluster_name }}
+{% if level == "contentqa" %}
+cluster.name: {{ elasticsearch_cluster_name }}_{{ ansible_hostname }}
+{% else %}
+cluster.name: {{ elasticsearch_cluster_name }}_{{ level }}
+{% endif %}
 {% endif %}
 
 #################################### Node #####################################

--- a/ansible/roles/frontend/vars/.gitignore
+++ b/ansible/roles/frontend/vars/.gitignore
@@ -1,3 +1,4 @@
 development.yml
 staging.yml
 production.yml
+contentqa.yml

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -39,7 +39,7 @@
 
 - name: Make sure our databases exist
   postgresql_db: >
-      name={{ item }} encoding=LATIN1 state=present template=template0
+      name={{ item }} encoding=UTF8 state=present template=template0
   sudo_user: postgres
   with_items:
     - dpla_portal

--- a/ansible/vars/.gitignore
+++ b/ansible/vars/.gitignore
@@ -1,3 +1,4 @@
 development.yml
 staging.yml
 production.yml
+contentqa.yml


### PR DESCRIPTION
This branch adds playbooks and roles for content QA hosts, which each have a large stack of services.  They have one each of the usually-clustered services, BigCouch and Elasticsearch.

There are various changes and fixes to account for this.  The added roles are not intended to be used on VMs, and the existing "development" playbooks should not touch them.

The main thing that I see possibly affecting the development VMs is the change to the PostgreSQL database's encoding, to account for the new default server locale of en_US.UTF8.  This needs to be tested in the development environment.
