### PR TITLE
Improve api build

### DIFF
--- a/ansible/roles/api/files/build_api.sh
+++ b/ansible/roles/api/files/build_api.sh
@@ -38,6 +38,6 @@ done
 # - mb
 cd /srv/www/api
 bundle exec rake jobs:clear \
-    && rm -rf tmp/qa_reports/* \
+    && bundle exec rake contentqa:delete_reports \
     && bundle exec rake tmp:clear \
     && bundle exec rake db:migrate


### PR DESCRIPTION
This changes API build script so that the log file and temporary directories are in place before rake tasks are run that could theoretically write log entries or create temporary files.

It also adds some rake tasks to clear out the delayed job queue, and QA reports directory, because there can be upgrade issues if that is not done and changes have been made to reports.

There are some subtleties that may not be getting addressed, but this should cover most cases of upgrading the QA app.
