### PR TITLE
Allow large uploads (>8MB) in WordPress/Omeka

### DIFF
--- a/ansible/roles/omeka/templates/application_config_config.ini.j2
+++ b/ansible/roles/omeka/templates/application_config_config.ini.j2
@@ -243,7 +243,7 @@ mail.transport.type = "Sendmail"
 ; configuration will not exceed the maximum beyond what is set in the 
 ; 'post_max_size' or 'upload_max_filesize' core php.ini directives.
 ;
-;upload.maxFileSize = "10M"
+upload.maxFileSize = "25M"
 
 
 ;;;;;;;;

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -171,6 +171,7 @@ server {
 
         proxy_cache_key     "$scheme://$host$request_uri $do_not_cache";
         proxy_pass          http://dpla_wp;
+        client_max_body_size 25M;
 
         # misc rewrites in the top level dir
         #
@@ -240,6 +241,7 @@ server {
         limit_req zone=pagereqzone burst=20;
 
         proxy_pass          http://dpla_omeka;
+        client_max_body_size 25M;
 
         # misc rewrites in the /exhibitions dir
         #


### PR DESCRIPTION
Mirrors the changes made in the PROD RS environment under Puppet.
