### PR TITLE
Change hostname variables

### DIFF
--- a/ansible/contentqa_all.yml
+++ b/ansible/contentqa_all.yml
@@ -38,7 +38,7 @@
       # will probably not be set up.
       ignore_errors: yes
       uri: >
-          url=http://{{ ansible_hostname }}:{{ api_app_port }}/v2/api_key/aa22-qa-app@dp.la
+          url=http://{{ inventory_hostname }}:{{ api_app_port }}/v2/api_key/aa22-qa-app@dp.la
           method=POST
       tags:
         - api

--- a/ansible/development
+++ b/ansible/development
@@ -1,12 +1,12 @@
 [loadbalancer]
-loadbal ansible_ssh_host=192.168.50.2 hostname=loadbal
+loadbal ansible_ssh_host=192.168.50.2
 
 [dbnodes]
-dbnode1 ansible_ssh_host=192.168.50.4 hostname=dbnode1
-dbnode2 ansible_ssh_host=192.168.50.5 hostname=dbnode2
+dbnode1 ansible_ssh_host=192.168.50.4
+dbnode2 ansible_ssh_host=192.168.50.5
 
 [webapps]
-webapp1 ansible_ssh_host=192.168.50.6 hostname=webapp1
+webapp1 ansible_ssh_host=192.168.50.6
 
 [frontend:children]
 webapps

--- a/ansible/roles/api/templates/dpla.yml.j2
+++ b/ansible/roles/api/templates/dpla.yml.j2
@@ -74,7 +74,7 @@ caching:
     - {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}
 {% endfor %}
 {% else %}
-    - {{ hostvars[ansible_hostname][internal_network_interface]['ipv4']['address'] }}
+    - {{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['address'] }}
     {% endif %}
 
 field_boosts:

--- a/ansible/roles/aws_postfix/templates/main.cf.j2
+++ b/ansible/roles/aws_postfix/templates/main.cf.j2
@@ -27,10 +27,10 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.
 
-myhostname = {{ ansible_hostname }}
+myhostname = {{ inventory_hostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
-mydestination = localdomain, localhost, localhost.localdomain, localhost, {{ ansible_hostname }}
+mydestination = localdomain, localhost, localhost.localdomain, localhost, {{ inventory_hostname }}
 relayhost = {{ smtp_relayhost_and_port }}
 mailbox_size_limit = 0
 recipient_delimiter = +

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Set hostname
-  hostname: name={{ hostname }}
+  hostname: name={{ inventory_hostname }}
   tags:
     - networking
 

--- a/ansible/roles/contentqa_proxy/templates/haproxy.cfg.j2
+++ b/ansible/roles/contentqa_proxy/templates/haproxy.cfg.j2
@@ -21,5 +21,5 @@ frontend http-in
 	default_backend http-contentqa
 
 backend http-contentqa
-	server {{ ansible_hostname }} {{ hostvars[ansible_hostname][internal_network_interface]['ipv4']['address'] }}:{{ api_app_port }} maxconn 500
+	server {{ inventory_hostname }} {{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['address'] }}:{{ api_app_port }} maxconn 500
 	

--- a/ansible/roles/dbnode/tasks/main.yml
+++ b/ansible/roles/dbnode/tasks/main.yml
@@ -39,7 +39,7 @@
   # This is the typical case.  There is a group of BigCouch nodes and you want
   # each node in the inventory file added to the cluster.
   uri: >
-      url="http://{{ hostname }}:5986/nodes/{{ dbnode_id_name }}@{{ item }}"
+      url="http://{{ inventory_hostname }}:5986/nodes/{{ dbnode_id_name }}@{{ item }}"
       method=PUT body="{}" status_code="201,409"
   with_items: groups['dbnodes']
   when: level != "contentqa"
@@ -52,7 +52,7 @@
   # want them talking to each other, even though there are multiple dbnodes in
   # the inventory.
   uri: >
-      url="http://{{ ansible_hostname }}:5986/nodes/{{ dbnode_id_name }}@{{ ansible_hostname }}"
+      url="http://{{ inventory_hostname }}:5986/nodes/{{ dbnode_id_name }}@{{ inventory_hostname }}"
       method=PUT body="{}" status_code="201,409"
   when: level == "contentqa"
   tags:

--- a/ansible/roles/dbnode/templates/local.ini.j2
+++ b/ansible/roles/dbnode/templates/local.ini.j2
@@ -13,7 +13,7 @@ socket_options = [{recbuf, 262144}, {sndbuf, 262144}, {nodelay, true}]
 
 [httpd]
 ; bind_address = 0.0.0.0
-bind_address = {{ hostvars[hostname][internal_network_interface]['ipv4']['address'] }}
+bind_address = {{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['address'] }}
 
 [query_servers]
 javascript = /opt/bigcouch/bin/couchjs -S 16384 /opt/bigcouch/share/couchjs/main.js

--- a/ansible/roles/dbnode/templates/vm.args.erb.j2
+++ b/ansible/roles/dbnode/templates/vm.args.erb.j2
@@ -2,7 +2,7 @@
 # (specified using -sname) or it can by fully qualified (-name).  There can be
 # no communication between nodes running with the -sname flag and those running 
 # with the -name flag.
--sname {{ dbnode_id_name }}@{{ hostname }}
+-sname {{ dbnode_id_name }}@{{ inventory_hostname }}
 
 # All nodes must share the same magic cookie for distributed Erlang to work.
 # Comment out this line if you synchronized the cookies by other means (using

--- a/ansible/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -27,7 +27,7 @@
 # cluster.name: elasticsearch
 {% if elasticsearch_cluster_name is defined %}
 {% if level == "contentqa" %}
-cluster.name: {{ elasticsearch_cluster_name }}_{{ ansible_hostname }}
+cluster.name: {{ elasticsearch_cluster_name }}_{{ inventory_hostname }}
 {% else %}
 cluster.name: {{ elasticsearch_cluster_name }}_{{ level }}
 {% endif %}
@@ -42,7 +42,7 @@ cluster.name: {{ elasticsearch_cluster_name }}_{{ level }}
 {# % if elasticsearch_node_name is defined % #}
 {# node.name: {{ elasticsearch_node_name }} #}
 {# % endif % #}
-node.name: {{ ansible_hostname }}
+node.name: {{ inventory_hostname }}
 
 # Every node can be configured to allow or deny being eligible as the master,
 # and to allow or deny to store the data.
@@ -262,7 +262,7 @@ network.publish_host: {{ elasticsearch_network_publish_host }}
 {# {% if elasticsearch_network_host is defined %} #}
 {# network.host: {{ elasticsearch_network_host }} #}
 {# {% endif %} #}
-network.host: {{ hostvars[ansible_hostname][internal_network_interface]['ipv4']['address'] }}
+network.host: {{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['address'] }}
 
 # Set a custom port for the node to node communication (9300 by default):
 #

--- a/ansible/roles/memcached/templates/memcached.conf.j2
+++ b/ansible/roles/memcached/templates/memcached.conf.j2
@@ -32,7 +32,7 @@ logfile /var/log/memcached.log
 # Specify which IP address to listen on. The default is to listen on all IP addresses
 # This parameter is one of the only security measures that memcached has, so make sure
 # it's listening on a firewalled interface.
--l {{ hostvars[ansible_hostname][internal_network_interface]['ipv4']['address'] }}
+-l {{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['address'] }}
 
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
 # -c 1024

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -56,7 +56,7 @@ external_pid_file = '/var/run/postgresql/9.1-main.pid'		# write an extra PID fil
 
 # - Connection Settings -
 
-listen_addresses = '{{ hostvars[ansible_hostname][internal_network_interface]['ipv4']['address'] }}'		# what IP address(es) to listen on;
+listen_addresses = '{{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['address'] }}'		# what IP address(es) to listen on;
 									# comma-separated list of addresses;
 									# defaults to 'localhost', '*' = all
 									# (change requires restart)


### PR DESCRIPTION
Use inventory_hostname in various places where hostname or
ansible_hostname were used.  inventory_hostname is automatically
assigned by ansible.  hostname was a variable I added before I
realized the availability of inventory_hostname.  ansible_hostname
is not appropriate because on the first pass through configuring a
new instance, it will not have been set yet to the desired hostname
for certain tasks (being the server's original hostname before we
set it).

This is a change that would help to have merged to `develop` before I perform more work for the staging environment.

I've run all of the plays in the `development` and `contentqa` environments and they look fine.  Could someone else do an ansible-playbook run?
