### PR TITLE
Use Elasticsearch 0.90.13

### DIFF
--- a/ansible/roles/elasticsearch/vars/main.yml
+++ b/ansible/roles/elasticsearch/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 
 elasticsearch_cluster_name: dpla
+elasticsearch_version: 0.90.13
 elasticsearch_plugins:
   - { name: 'elasticsearch/elasticsearch-lang-javascript/1.4.0'}
   - { name: 'elasticsearch/elasticsearch-river-couchdb/1.3.0'}


### PR DESCRIPTION
We are currently using Elasticsearch 0.90.13 in our current environments.
