### PR TITLE
Add staging

### DIFF
--- a/ansible/playbooks/deploy_api_staging.yml
+++ b/ansible/playbooks/deploy_api_staging.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Deploy API (staging)
+  hosts: api
+  sudo: yes
+  tasks:
+    - include: ../roles/api/tasks/deploy.yml
+  handlers:
+    - include: ../roles/api/handlers/main.yml
+  vars:
+    level: staging
+  vars_files:
+    - "../vars/staging.yml"
+    - "../roles/api/defaults/main.yml"
+    - "../roles/api/vars/staging.yml"

--- a/ansible/playbooks/deploy_frontend_staging.yml
+++ b/ansible/playbooks/deploy_frontend_staging.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Deploy frontend (staging)
+  hosts: frontend
+  sudo: yes
+  tasks:
+    - include: ../roles/frontend/tasks/deploy.yml
+  handlers:
+    - include: ../roles/frontend/handlers/main.yml
+  vars:
+    level: staging
+  vars_files:
+    - "../vars/staging.yml"
+    - "../roles/frontend/defaults/main.yml"
+    - "../roles/frontend/vars/staging.yml"

--- a/ansible/playbooks/ingestion.yml
+++ b/ansible/playbooks/ingestion.yml
@@ -1,0 +1,27 @@
+---
+
+- hosts: ingestion
+  sudo: yes
+  tasks:
+    - name: Make sure that the "dpla" user exists
+      user: >
+          name=dpla comment="DPLA application user"
+          home=/home/dpla shell=/bin/bash state=present
+    - name: Ensure that Python dependencies are installed
+      # Most of these are necessary for building Python with pyenv, and g++ is
+      # included under the assumption that some module may need it
+      apt: >
+          pkg="{{ item }}" state=present
+      with_items:
+        - git
+        - gcc
+        - g++
+        - build-essential
+        - libssl-dev
+        - zlib1g-dev
+        - libbz2-dev
+        - libreadline-dev
+        - libsqlite3-dev
+        - wget
+        - llvm
+

--- a/ansible/roles/postgresql/templates/pg_hba.conf.j2
+++ b/ansible/roles/postgresql/templates/pg_hba.conf.j2
@@ -76,6 +76,9 @@
 {% for host in groups['frontend'] %}
 host   all             all            {{ host }}             md5
 {% endfor %}
+{% for host in groups['api'] %}
+host   all             all            {{ host }}             md5
+{% endfor %}
 
 # Deny access to postgresql user from other hosts
 host    all             postgres       0.0.0.0/0               reject

--- a/ansible/staging_all.yml
+++ b/ansible/staging_all.yml
@@ -1,0 +1,77 @@
+---
+
+- name: Common
+  hosts: all
+  sudo: yes
+  roles:
+    - common
+    - aws_postfix
+  vars:
+    level: staging
+  vars_files:
+    - ["vars/staging.yml", "vars/defaults.yml"]
+
+- include: playbooks/dbnodes.yml level=staging
+
+- include: playbooks/elasticsearch.yml level=staging
+
+- include: playbooks/postgresql.yml level=staging
+
+- include: playbooks/mysql.yml level=staging
+
+- include: playbooks/memcached.yml level=staging
+
+- name: Common httpd configuration
+  hosts:
+    - api
+    - frontend
+    - site_proxies
+    - cms-stg
+  sudo: yes
+  roles:
+    - common_web
+  vars:
+    level: staging
+  vars_files:
+    - ["vars/staging.yml", "vars/defaults.yml"]
+
+- name: Site proxies
+  # This play should come before the other web-related ones to ensure that the
+  # site proxy cache exists before the other ones try to clear it.
+  hosts:
+    - site_proxies
+  sudo: yes
+  roles:
+    - site_proxy
+  vars:
+    level: staging
+  vars_files:
+    - ["vars/staging.yml", "vars/defaults.yml"]
+
+- name: Content management systems
+  hosts:
+    - cms-stg
+  sudo: yes
+  roles:
+    - common_php
+    - common_sitenode
+    - omeka
+    - wordpress
+  vars:
+    level: staging
+  vars_files:
+    - ["vars/staging.yml", "vars/defaults.yml"]
+
+- name: Frontend (portal) site
+  hosts: frontend
+  sudo: yes
+  roles:
+    - frontend
+  vars:
+    level: staging
+  vars_files:
+    - ["vars/staging.yml", "vars/defaults.yml"]
+
+- include: playbooks/api.yml level=staging
+
+- include: playbooks/ingestion.yml


### PR DESCRIPTION
This adds playbooks for staging servers, which have certain variables and host groups that are different than development or contentqa.

The only change that will get interpreted in other environments is the addition of a PostgreSQL access control entry, which will not make any difference in development or contentqa.  There's a new playbook for the `ingestion` group, but that won't get run in the current contentqa or development environments.  It could be added to those later.
