### PR TITLE
Dynamically set WordPress HOME and site URL

### DIFF
--- a/ansible/roles/wordpress/templates/wp-config.php.j2
+++ b/ansible/roles/wordpress/templates/wp-config.php.j2
@@ -1,7 +1,7 @@
 <?php
 
-define('WP_HOME', 'http://{{ frontend_hostname }}/info');
-define('WP_SITEURL', 'http://{{ frontend_hostname }}/info');
+define('WP_HOME', 'http://'. $_SERVER['HTTP_HOST'] .'/info');
+define('WP_SITEURL', 'http://'. $_SERVER['HTTP_HOST'] .'/info');
 
 /** The name of the database for WordPress */
 define('DB_NAME', 'dpla_wp');
@@ -77,7 +77,7 @@ define('WP_DEBUG_LOG', {{ debug_value }});
 define('WP_DEBUG_DISPLAY', {{ debug_value }});
 
 define('DPLA_API_KEY', '{{ api_key }}');
-define('DPLA_FRONTEND_URL', 'http://{{ frontend_hostname }}/');
+define('DPLA_FRONTEND_URL', 'http://{{ frontend_hostname }}');
 define('DPLA_API_URL', 'http://{{ api_hostname }}/v2');
 
 


### PR DESCRIPTION
This should allow us to temporarily use another CNAME to verify
the WordPress install before we switch it to prod. The navigation
links should now also work as expected. Once we get closer to
the final production deployment this should be switched back to
use the `frontend_hostname` variable.
