### PR TITLE
Add php5-curl to common_php nodes (fixes #7724)

### DIFF
--- a/ansible/roles/common_php/tasks/main.yml
+++ b/ansible/roles/common_php/tasks/main.yml
@@ -4,6 +4,7 @@
   apt: >
       pkg="{{ item }}" state=present force=yes
   with_items:
+    - php5-curl
     - php5-fpm
     - php5-imagick
     - php5-mcrypt


### PR DESCRIPTION
Required for Omeka to dynamically pull metadata from the API.

See https://issues.dp.la/issues/7724.
