### PR TITLE
Use environment-level variables for frontend (fixes #7728)

### DIFF
--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -1,5 +1,13 @@
 ---
 
+- include_vars: "../vars/{{ level }}.yml"
+  when: level is defined
+  tags:
+    - deployment
+    - frontend
+    - frontend_deployment
+    - web
+
 - name: Check out frontend app from its repository
   git: >
       repo=https://github.com/dpla/frontend.git

--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 
+- include_vars: "../vars/{{ level }}.yml"
+  when: level is defined
+  tags:
+    - frontend
+    - web
+    - nginx
+
 - name: Ensure existence of necessary packages
   apt: >
       pkg="{{ item }}" state=present


### PR DESCRIPTION
The frontend was not having the `rails_env` set properly when `/usr/local/sbin/start_unicorn_frontend.sh` was built; this should fix that.
