### PR TITLE
Add reboot and upgrade playbooks

### DIFF
--- a/ansible/development
+++ b/ansible/development
@@ -23,6 +23,9 @@ webapps
 [exhibitions:children]
 webapps
 
+[cms:children]
+webapps
+
 [mysql_dbs:children]
 webapps
 

--- a/ansible/playbooks/package_upgrade.yml
+++ b/ansible/playbooks/package_upgrade.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Upgrade o/s packages
+  hosts: all
+  sudo: yes
+  tasks:
+    - name: Update apt package index
+      apt: update_cache=yes
+      tags:
+        - packages
+    - name: Upgrade apt packages
+      apt: upgrade=safe
+      tags:
+        - packages

--- a/ansible/playbooks/pre_post_tasks/api_posttasks.yml
+++ b/ansible/playbooks/pre_post_tasks/api_posttasks.yml
@@ -4,7 +4,8 @@
   sudo: false
   local_action: >
       wait_for host="{{ inventory_hostname }}" port="{{ api_app_port }}"
-      delay=2 timeout=30
+      delay={{ delay | default(2) }}
+      timeout={{ timeout | default(30) }}
 - name: Register instance with loadbalancer again
   # Note that, on initialization of the whole environment, when there are
   # no origin servers yet behind the loadbalancer, this task could fail if
@@ -12,7 +13,8 @@
   # various status codes that could result from everything not being set
   # up yet.  You can get around this by having the loadbalancer simply
   # probe for port 80 while you're initializing everything, and then
-  # switch it later to a HTTP check for "/".
+  # switch it later to a HTTP check for a success response from a
+  # particular resource.
   local_action: ec2_elb
   when: level == 'production' or level == 'staging'
   sudo: false

--- a/ansible/playbooks/pre_post_tasks/api_pretasks.yml
+++ b/ansible/playbooks/pre_post_tasks/api_pretasks.yml
@@ -14,3 +14,10 @@
     aws_secret_key: "{{ aws_secret_key }}"
     aws_region: "{{ aws_region }}"
     state: absent
+# TODO:  when Ansible 1.8 is released, enable the following
+# and require Ansible 1.8.
+# - name: Wait for connections to drain
+#   sudo: false
+#   local_action: >-
+#       wait_for host="{{ inventory_hostname }}" port="{{ api_app_port }}"
+#       state=drained timeout=60

--- a/ansible/playbooks/reboot.yml
+++ b/ansible/playbooks/reboot.yml
@@ -1,0 +1,37 @@
+---
+
+# Reboot staging or production
+
+- name: Instances that can be rebooted in parallel
+  # TODO:  pre and post tasks that put cms sites and frontend
+  # into maintenance mode, perhaps via the siteproxies.
+  # (503 Service Unavailable, custom maintenance page)
+  # Otherwise, there could be 502 Gateway Error or 500 Server Error
+  # responses whent the PostgreSQL database or CMS webserver go
+  # offline.
+  hosts:
+    - ingestion
+    - cms
+    - postgresql_dbs
+  sudo: yes
+  tasks:
+    - name: Reboot
+      command: /sbin/shutdown -r now
+      async: 0
+      poll: 0
+      ignore_errors: true
+    - name: Wait for server to come back up
+      sudo: false
+      local_action: >-
+          wait_for host="{{ inventory_hostname }}" port="22"
+          delay=60 timeout=500
+
+- include: reboot_dbnodes.yml
+
+- include: reboot_elasticsearch.yml
+
+- include: reboot_api.yml
+
+- include: reboot_frontend.yml
+
+- include: reboot_siteproxy.yml

--- a/ansible/playbooks/reboot_api.yml
+++ b/ansible/playbooks/reboot_api.yml
@@ -1,0 +1,21 @@
+---
+
+
+- name: Reboot API instances
+  hosts: api
+  serial: 1
+  sudo: yes
+  pre_tasks:
+  tasks:
+    - include: pre_post_tasks/api_pretasks.yml
+    - name: Reboot
+      command: /sbin/shutdown -r now
+      async: 0
+      poll: 0
+      ignore_errors: true
+    - include: pre_post_tasks/api_posttasks.yml
+      vars:
+          delay: 60
+          timeout: 600
+  vars_files:
+    - ["../vars/{{ level }}.yml", "../vars/defaults.yml"]

--- a/ansible/playbooks/reboot_dbnodes.yml
+++ b/ansible/playbooks/reboot_dbnodes.yml
@@ -1,0 +1,46 @@
+---
+
+- name: Reboot repository database instances
+  hosts:
+    - dbnodes
+  serial: 1
+  sudo: yes
+  tasks:
+    - name: Gather ec2 facts
+      ec2_facts:
+    - name: De-register instance from loadbalancer
+      local_action: ec2_elb
+      sudo: false
+      args:
+        instance_id: "{{ ansible_ec2_instance_id }}"
+        ec2_elbs: "{{ bigcouch_elb_name }}"
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        aws_region: "{{ aws_region }}"
+        state: absent
+    # TODO:  when Ansible 1.8 is released, check for connnection draining
+    # with `wait_for ... state=drained'.
+    - name: Reboot
+      command: /sbin/shutdown -r now
+      async: 0
+      poll: 0
+      ignore_errors: true
+    - name: Wait for instance to come back up
+      sudo: false
+      local_action: >-
+          wait_for host="{{ inventory_hostname }}"
+          port="5984" delay=60 timeout=600
+    - name: Register instance with loadbalancer again
+      sudo: false
+      local_action: ec2_elb
+      when: level == 'production' or level == 'staging'
+      sudo: false
+      args:
+        instance_id: "{{ ansible_ec2_instance_id }}"
+        ec2_elbs: "{{ bigcouch_elb_name }}"
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        aws_region: "{{ aws_region }}"
+        state: present
+  vars_files:
+    - ["../vars/{{ level }}.yml", "../vars/defaults.yml"]

--- a/ansible/playbooks/reboot_elasticsearch.yml
+++ b/ansible/playbooks/reboot_elasticsearch.yml
@@ -1,0 +1,66 @@
+---
+
+- hosts: 127.0.0.1
+  connection: local
+  sudo: false
+  tasks:
+    - name: Turn off shard replica allocation
+      local_action: >-
+          script ../files/set-allocation.sh off "{{ es_cluster_loadbal }}"
+  vars_files:
+    - ["../vars/{{ level }}.yml", "../vars/defaults.yml"]
+
+- name: Reboot search instances
+  hosts:
+    - elasticsearch
+  serial: 1
+  sudo: yes
+  tasks:
+    - name: Gather ec2 facts
+      ec2_facts:
+    - name: De-register instance from loadbalancer
+      local_action: ec2_elb
+      sudo: false
+      args:
+        instance_id: "{{ ansible_ec2_instance_id }}"
+        ec2_elbs: "{{ es_elb_name }}"
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        aws_region: "{{ aws_region }}"
+        state: absent
+    # TODO:  when Ansible 1.8 is released, check for connnection draining
+    # with `wait_for ... state=drained'.
+    - name: Reboot
+      command: /sbin/shutdown -r now
+      async: 0
+      poll: 0
+      ignore_errors: true
+    - name: Wait for instance to come back up
+      sudo: false
+      local_action: >-
+          wait_for host="{{ inventory_hostname }}"
+          port="9200" delay=60 timeout=600
+    - name: Register instance with loadbalancer again
+      sudo: false
+      local_action: ec2_elb
+      when: level == 'production' or level == 'staging'
+      sudo: false
+      args:
+        instance_id: "{{ ansible_ec2_instance_id }}"
+        ec2_elbs: "{{ es_elb_name }}"
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        aws_region: "{{ aws_region }}"
+        state: present
+  vars_files:
+    - ["../vars/{{ level }}.yml", "../vars/defaults.yml"]
+
+- hosts: 127.0.0.1
+  connection: local
+  sudo: false
+  tasks:
+    - name: Turn shard replica allocation back on
+      local_action: >-
+          script ../files/set-allocation.sh on "{{ es_cluster_loadbal }}"
+  vars_files:
+    - ["../vars/{{ level }}.yml", "../vars/defaults.yml"]

--- a/ansible/playbooks/reboot_frontend.yml
+++ b/ansible/playbooks/reboot_frontend.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Reboot frontend
+  hosts: frontend
+  sudo: true
+  serial: 1
+  tasks:
+    # There is nothing fancy to do yet with the frontend servers because
+    # they're behind Nginx, not a loadbalancer with an API for removing
+    # nodes from the pool.  Our Nginx configuration has it hit
+    # the next available origin server when the first one is down.
+    - name: Reboot
+      command: /sbin/shutdown -r now
+      async: 0
+      poll: 0
+      ignore_errors: true
+    - name: Wait for instance to come back up
+      sudo: false
+      local_action: >-
+          wait_for host="{{ inventory_hostname }}"
+          port="{{ frontend_app_port }}" delay=60 timeout=600
+  vars_files:
+    - ["../vars/{{ level }}.yml", "../vars/defaults.yml"]

--- a/ansible/playbooks/reboot_production.yml
+++ b/ansible/playbooks/reboot_production.yml
@@ -1,0 +1,3 @@
+---
+
+- include: reboot.yml level=production

--- a/ansible/playbooks/reboot_siteproxy.yml
+++ b/ansible/playbooks/reboot_siteproxy.yml
@@ -1,0 +1,45 @@
+---
+
+- name: Reboot site proxies
+  hosts: site_proxies
+  sudo: true
+  serial: 1
+  tasks:
+    - name: Gather ec2 facts
+      ec2_facts:
+    - name: De-register instance from loadbalancer
+      local_action: ec2_elb
+      sudo: false
+      args:
+        instance_id: "{{ ansible_ec2_instance_id }}"
+        ec2_elbs: "{{ siteproxy_elb_name }}"
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        aws_region: "{{ aws_region }}"
+        state: absent
+    # TODO:  when Ansible 1.8 is released, check for connnection draining
+    # with `wait_for ... state=drained'.
+    - name: Reboot
+      command: /sbin/shutdown -r now
+      async: 0
+      poll: 0
+      ignore_errors: true
+    - name: Wait for instance to come back up
+      sudo: false
+      local_action: >-
+          wait_for host="{{ inventory_hostname }}"
+          port="80" delay=60 timeout=600
+    - name: Register instance with loadbalancer again
+      sudo: false
+      local_action: ec2_elb
+      when: level == 'production' or level == 'staging'
+      sudo: false
+      args:
+        instance_id: "{{ ansible_ec2_instance_id }}"
+        ec2_elbs: "{{ siteproxy_elb_name }}"
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        aws_region: "{{ aws_region }}"
+        state: present
+  vars_files:
+    - ["../vars/{{ level }}.yml", "../vars/defaults.yml"]

--- a/ansible/playbooks/reboot_staging.yml
+++ b/ansible/playbooks/reboot_staging.yml
@@ -1,0 +1,3 @@
+---
+
+- include: reboot.yml level=staging


### PR DESCRIPTION
These playbooks allow you to safely perform o/s package upgrades of the staging and production servers and reboot them.  They are not relevant to development or contentqa.
