### PR TITLE
Add rotation of API and frontend logs

### DIFF
--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -112,4 +112,13 @@
     - web
     - htpasswd
 
+- name: Make sure that API app logs get rotated
+  template: >-
+      src=etc_logrotate.d_api_rails_logs.j2
+      dest=/etc/logrotate.d/api_rails_logs
+      owner=root group=root mode=0644
+  tags:
+    - api
+    - logrotate
+
 - include: deploy.yml

--- a/ansible/roles/api/templates/etc_logrotate.d_api_rails_logs.j2
+++ b/ansible/roles/api/templates/etc_logrotate.d_api_rails_logs.j2
@@ -1,0 +1,33 @@
+/srv/www/api/var/log/elasticsearch-{{ rails_env }}.log
+/srv/www/api/var/log/{{ rails_env }}.log
+/srv/www/api/var/log/unicorn.stderr.log
+/srv/www/api/var/log/unicorn.stdout.log
+{
+    daily
+    missingok
+    rotate 60
+    compress
+    delaycompress
+    dateext
+    notifempty
+    create 0644 dpla dpla
+    sharedscripts
+    postrotate
+        service unicorn_api reload
+    endscript
+}
+
+/srv/www/api/var/log/delayed_job.log
+{
+    weekly
+    missingok
+    rotate 8
+    delaycompress
+    dateext
+    notifempty
+    create 0644 dpla dpla
+    sharedscripts
+    postrotate
+        service unicorn_api reload
+    endscript
+}

--- a/ansible/roles/contentqa_proxy/tasks/main.yml
+++ b/ansible/roles/contentqa_proxy/tasks/main.yml
@@ -33,3 +33,4 @@
   tags:
     - contentqa_proxy
     - rsyslog
+    - logrotate

--- a/ansible/roles/dbnode/tasks/main.yml
+++ b/ansible/roles/dbnode/tasks/main.yml
@@ -68,3 +68,5 @@
   copy: src=etc_logrotate_d_bigcouch dest=/etc/logrotate.d/bigcouch owner=root group=root mode=0644
   tags:
     - database
+    - logrotate
+

--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -66,5 +66,15 @@
     - nginx
     - web
 
+- name: Make sure that frontend app logs get rotated
+  template: >-
+      src=etc_logrotate.d_frontend_rails_logs.j2
+      dest=/etc/logrotate.d/frontend_rails_logs
+      owner=root group=root mode=0644
+  tags:
+    - frontend
+    - web
+    - logrotate
+
 
 - include: deploy.yml

--- a/ansible/roles/frontend/templates/etc_logrotate.d_frontend_rails_logs.j2
+++ b/ansible/roles/frontend/templates/etc_logrotate.d_frontend_rails_logs.j2
@@ -1,0 +1,18 @@
+/srv/www/frontend/log/{{ rails_env }}.log
+/srv/www/frontend/log/unicorn.stderr.log
+/srv/www/frontend/log/unicorn.stdout.log
+{
+    daily
+    missingok
+    rotate 60
+    compress
+    delaycompress
+    dateext
+    notifempty
+    create 0644 dpla dpla
+    sharedscripts
+    postrotate
+        service unicorn_frontend reload
+    endscript
+
+}


### PR DESCRIPTION
This adds rotation of the platform (API) and frontend rails app logs.
To see this work in development, deploy the changes like so:

```
ansible-playbook -u <you> -i development dev_all.yml -t logrotate
```

Then, to manually test the logrotate command:

```
ssh you@webapp1
sudo logrotate -f /etc/logrotate.d/api_rails_logs
sudo logrotate -f /etc/logrotate.d/frontend_rails_logs
```

Then look in `/srv/www/api/var/log` and `/srv/www/frontend/log`.
