### PR TITLE
Redirect "www" requests

### DIFF
--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -271,3 +271,11 @@ server {
         deny  all;
     }
 }
+
+server {
+    listen 80;
+    server_name www.{{ frontend_hostname }};
+    location / {
+        rewrite ^(.*)$ http://{{ frontend_hostname }}$1 permanent;
+    }
+}


### PR DESCRIPTION
Redirect "www.domain" to "domain", for search engine optimization.
See https://issues.dp.la/issues/7733
Tested in development and staging.
