### PR TITLE
Fix haproxy log rotation on contentqa

### DIFF
--- a/ansible/roles/contentqa_proxy/files/etc_logrotate.d_haproxy
+++ b/ansible/roles/contentqa_proxy/files/etc_logrotate.d_haproxy
@@ -1,4 +1,4 @@
-/var/log/haproxy*
+/var/log/haproxy.log
 {
     rotate 7
     daily


### PR DESCRIPTION
The `logrotate` configuration for `haproxy` on the `contentqa_proxy` role had a wildcard leading to uncontrolled generation of files like the following:

```
haproxy.log.6.gz.2.gz.1.2.gz.1.1.1.2.gz.1.2.gz.2.gz.1.2.gz.1.1
haproxy.log.6.gz.2.gz.1.2.gz.1.1.1.2.gz.1.2.gz.2.gz.1.2.gz.1.1.1
haproxy.log.6.gz.2.gz.1.2.gz.1.1.1.2.gz.1.2.gz.2.gz.1.2.gz.1.2.gz
haproxy.log.6.gz.2.gz.1.2.gz.1.1.1.2.gz.1.2.gz.2.gz.1.2.gz.2.gz
haproxy.log.6.gz.2.gz.1.2.gz.1.1.1.2.gz.1.2.gz.2.gz.1.3.gz
```
