### PR TITLE
Improve NGINX worker, connections, and body size

### DIFF
--- a/ansible/roles/common_web/templates/etc_nginx_nginx.conf.j2
+++ b/ansible/roles/common_web/templates/etc_nginx_nginx.conf.j2
@@ -1,9 +1,9 @@
 user www-data;
-worker_processes 4;
+worker_processes {{ hostvars[inventory_hostname]['ansible_processor_cores'] }};
 pid /var/run/nginx.pid;
 
 events {
-	worker_connections 768;
+	worker_connections 1000;
 	# multi_accept on;
 }
 
@@ -19,8 +19,7 @@ http {
 	keepalive_timeout 65;
 	types_hash_max_size 2048;
 
-	# NOTE: site-node has client_max_body_size 25m
-	# this can go in server or location.
+	# client_max_body_size is defined in individual virtual hosts.
 
 	# server_tokens off;
 

--- a/ansible/roles/omeka/templates/etc_nginx_sites_available_omeka.j2
+++ b/ansible/roles/omeka/templates/etc_nginx_sites_available_omeka.j2
@@ -4,9 +4,8 @@ server {
     listen {{ exhibitions_app_port }};
     server_name default;
 
-    # It's unclear if client_max_body_size is necessary.  It was in the
-    # configuration from which this one has been transferred (albeit in
-    # nginx.conf, not this equivalent file).  --MB
+    # This large maximum request body size is assumed to be necessary for
+    # media file uploads.  Also see the siteproxy configuration.
     client_max_body_size 25m;
 
     location /exhibitions {

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -174,7 +174,11 @@ server {
 
         proxy_cache_key     "$scheme://$host$request_uri $do_not_cache";
         proxy_pass          http://dpla_wp;
-        client_max_body_size 25M;
+
+        # For client_max_body_size, see the Wordpress role's NGINX virtual host
+        # configuration.
+        # (ansible/roles/wordpress/templates/etc_nginx_sites_available_wordpress.j2)
+        client_max_body_size 8m;
 
         # misc rewrites in the top level dir
         #
@@ -244,6 +248,9 @@ server {
         limit_req zone=pagereqzone burst=20;
 
         proxy_pass          http://dpla_omeka;
+        # For client_max_body_size, see the Omeka role's NGINX virtual host
+        # configuration.
+        # (ansible/roles/omeka/templates/etc_nginx_sites_available_omeka.j2)
         client_max_body_size 25M;
 
         # misc rewrites in the /exhibitions dir

--- a/ansible/roles/wordpress/templates/etc_nginx_sites_available_wordpress.j2
+++ b/ansible/roles/wordpress/templates/etc_nginx_sites_available_wordpress.j2
@@ -7,6 +7,11 @@ server {
     root /srv/www/wordpress;
     index index.php;
 
+    # Maximum client request body size, which affects uploads.
+    # Also see the same setting as defined upstream in the proxy server's
+    # configuration.
+    client_max_body_size 8m;
+
     access_log /var/log/nginx/wordpress-access.log;
     error_log /var/log/nginx/wordpress-error.log;
 

--- a/ansible/roles/wordpress/templates/etc_php5_fpm_pool.d_wp.conf.j2
+++ b/ansible/roles/wordpress/templates/etc_php5_fpm_pool.d_wp.conf.j2
@@ -21,3 +21,4 @@ slowlog = /var/log/php-fpm/wp-slow.log
 catch_workers_output = no
 php_admin_value[error_log] = /var/log/wp-error.log
 php_admin_flag[log_errors] = on
+php_admin_value[upload_max_filesize] = 8M


### PR DESCRIPTION
- Parameterize NGINX worker_processes to automatically reflect the
  number of CPU cores in the system.
- Set higher worker_connections, which should be fine given the
  number of allowed open file descriptors.
- Update some comments about client_max_body_size.  Explicitly
  declare this in the Wordpress NGINX virtual host, and make it
  consistent between blocks that relate to the frontend site.

I've deployed these configuration changes to staging, and all appears well.  I have tested an upload to the exhibitions site, to confirm that I haven't messed up the client maximum body size there.
