### PR TITLE
Fix Unicorn restarts during deployments

### DIFF
--- a/ansible/roles/api/handlers/main.yml
+++ b/ansible/roles/api/handlers/main.yml
@@ -1,8 +1,5 @@
 ---
 
-- name: restart unicorn
-  service: name=unicorn_api state=reloaded
-
 - name: restart delayed job
   service: name=delayed_job_api state=restarted
 

--- a/ansible/roles/api/tasks/deploy.yml
+++ b/ansible/roles/api/tasks/deploy.yml
@@ -81,6 +81,18 @@
     - api_deployment
     - web
 
+- name: Stop Unicorn (gracefully)
+  # Unicorn is stopped completely, and later restarted, because we assume that
+  # preload_app is true, and this option means that a SIGHUP to reload Unicorn's
+  # configuration won't cause it to reload program code.  In a setting other than
+  # development, the loadbalancer in front of the API node will be routing requests
+  # to the other servers in the same pool.
+  service: name=unicorn_api state=stopped
+  tags:
+    - deployment
+    - api
+    - api_deployment
+    - web
 
 - name: Build api app
   script: >
@@ -88,7 +100,6 @@
   sudo_user: dpla
   notify:
     - restart delayed job
-    - restart unicorn
     - restart memcached
   tags:
     - deployment
@@ -100,6 +111,14 @@
   command: find /var/cache/nginx -type f -delete
   delegate_to: "{{ item }}"
   with_items: groups.site_proxies
+  tags:
+    - deployment
+    - api
+    - api_deployment
+    - web
+
+- name: Start Unicorn
+  service: name=unicorn_api state=started
   tags:
     - deployment
     - api

--- a/ansible/roles/api/templates/etc_init.d_unicorn_api.j2
+++ b/ansible/roles/api/templates/etc_init.d_unicorn_api.j2
@@ -57,6 +57,7 @@ start)
     fi
     ;;
 stop)
+    # QUIT triggers a graceful stop acc. to http://unicorn.bogomips.org/SIGNALS.html
     sig QUIT && exit 0
     echo >&2 "Not running"
     ;;

--- a/ansible/roles/frontend/handlers/main.yml
+++ b/ansible/roles/frontend/handlers/main.yml
@@ -1,7 +1,4 @@
 ---
 
-- name: restart unicorn
-  service: name=unicorn_frontend state=reloaded
-
 - name: restart nginx
   service: name=nginx state=reloaded

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -103,19 +103,23 @@
     - frontend_deployment
     - web
 
-- name: Build frontend app
-  script: >
-      build_frontend.sh {{ ruby_rbenv_version }}
-  sudo_user: dpla
-  notify: restart unicorn
+- name: Stop Unicorn (gracefully)
+  # Unicorn is stopped completely, and later restarted, because we assume that
+  # preload_app is true, and this option means that a SIGHUP to reload Unicorn's
+  # configuration won't cause it to reload program code.  In a setting other than
+  # development, the NGINX reverse-proxy in front of Unicorn will be routing requests
+  # to the other servers in the same pool.
+  service: name=unicorn_frontend state=stopped
   tags:
     - deployment
     - frontend
     - frontend_deployment
     - web
 
-- name: Remove temporary private key for GitHub
-  file: path=/home/dpla/git_private_key state=absent
+- name: Build frontend app
+  script: >
+      build_frontend.sh {{ ruby_rbenv_version }}
+  sudo_user: dpla
   tags:
     - deployment
     - frontend
@@ -141,3 +145,20 @@
     - frontend
     - frontend_deployment
     - web
+
+- name: Start Unicorn
+  service: name=unicorn_frontend state=started
+  tags:
+    - deployment
+    - frontend
+    - frontend_deployment
+    - web
+
+- name: Remove temporary private key for GitHub
+  file: path=/home/dpla/git_private_key state=absent
+  tags:
+    - deployment
+    - frontend
+    - frontend_deployment
+    - web
+

--- a/ansible/roles/frontend/templates/etc_init.d_unicorn_frontend.j2
+++ b/ansible/roles/frontend/templates/etc_init.d_unicorn_frontend.j2
@@ -57,6 +57,7 @@ start)
     fi
     ;;
 stop)
+    # QUIT triggers a graceful stop acc. to http://unicorn.bogomips.org/SIGNALS.html
     sig QUIT && exit 0
     echo >&2 "Not running"
     ;;


### PR DESCRIPTION
- Ensure that program code gets reloaded by completely stopping
  and, later, restarting.
- Augment and reorder deployment tasks, and remove handlers.

Restarts are done as `api` and `frontend` role deployment tasks,
rather than as pre_tasks and post_tasks, for consistency between
both roles.

I've run deployments on development and staging and they've succeeded.
