### PR TITLE
Deploy Omeka tag v18.0.2 by default and allow Omeka-specific API key

### DIFF
--- a/ansible/roles/omeka/defaults/main.yml
+++ b/ansible/roles/omeka/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
-exhibitions_branch_or_tag: "v16.1"
+exhibitions_branch_or_tag: "v18.0.2"
+exhibitions_api_key: "{{ api_key }}"
 
 # PHP-FPM tuning parameters
 omeka_php_max_children: 10

--- a/ansible/roles/omeka/templates/application_config_config.ini.j2
+++ b/ansible/roles/omeka/templates/application_config_config.ini.j2
@@ -266,7 +266,7 @@ dpla.wordpressURL = '/info'
 dpla.apiUrl = 'http://{{ api_hostname }}:{{ api_port }}/v2'
 
 ; API key
-dpla.apiKey = '{{ api_key }}';
+dpla.apiKey = '{{ exhibitions_api_key }}';
 
 ; exhibitions browse: default size of the page. Means, how much exhibits display on first page. Other exhibits would be displayed with pagination
 dpla.exhibit_page_size = 16


### PR DESCRIPTION
- Exhibitions was previously set to tag v16.1
- Allow Omeka to use its own specific API key. This allows us to
  more easily filter out API requests from Omeka in our monthly
  statistics.
