### PR TITLE
Add relational db dump backups

### DIFF
--- a/ansible/playbooks/contentqa_webapps.yml
+++ b/ansible/playbooks/contentqa_webapps.yml
@@ -4,7 +4,7 @@
 
 - include: postgresql.yml
 
-- include: mysql.yml
+# Note that contentqa does not have MySQL.
 
 - include: memcached.yml
 

--- a/ansible/playbooks/mysql_contentqa.yaml
+++ b/ansible/playbooks/mysql_contentqa.yaml
@@ -1,3 +1,0 @@
----
-
-- include: mysql.yml level=contentqa

--- a/ansible/roles/aws_postfix/templates/generic.j2
+++ b/ansible/roles/aws_postfix/templates/generic.j2
@@ -5,6 +5,8 @@ ubuntu         {{ admin_notifications_from }}
 www-data       {{ admin_notifications_from }}
 munin          {{ admin_notifications_from }}
 dpla           {{ admin_notifications_from }}
+postgres       {{ admin_notifications_from }}
+mysql          {{ admin_notifications_from }}
 root           {{ admin_notifications_from }}
 
 # PHP-FPM (I believe) provides the virtual host name

--- a/ansible/roles/mysql/defaults/main.yml
+++ b/ansible/roles/mysql/defaults/main.yml
@@ -4,3 +4,4 @@ mysql_root_password: changeme
 mysql_users:
   - {name: "dpla_omeka", password: "changeme"}
   - {name: "dpla_wordpress", password: "changeme"}
+mysql_backup_keep_days: 30

--- a/ansible/roles/mysql/tasks/main.yml
+++ b/ansible/roles/mysql/tasks/main.yml
@@ -74,3 +74,20 @@
   tags:
     - mysql
     - mysql_user
+
+- name: Make sure that the backups directory exists
+  file: path=/backups state=directory owner=root group=root mode=0755
+  tags:
+    - mysql
+- name: Make sure that the PostgreSQL backups directory exists
+  file: path=/backups/mysql state=directory owner=root group=root mode=0770
+  tags:
+    - mysql
+
+- name: Ensure state of crontab file
+  template: >-
+      src=etc_cron.d_backup-mysql.j2 dest=/etc/cron.d/backup-mysql
+      owner=root group=root mode=0644
+  tags:
+    - mysql
+

--- a/ansible/roles/mysql/templates/etc_cron.d_backup-mysql.j2
+++ b/ansible/roles/mysql/templates/etc_cron.d_backup-mysql.j2
@@ -1,0 +1,5 @@
+
+10 3 * * * root ts=`date +'\%Y-\%m-\%d'`; fn="/backups/mysql/dpla_omeka_$ts.sql.gz"; mysqldump --opt dpla_omeka | gzip > $fn
+11 3 * * * root ts=`date +'\%Y-\%m-\%d'`; fn="/backups/mysql/dpla_wp_$ts.sql.gz"; mysqldump --opt dpla_wp | gzip > $fn
+12 3 * * * root ts=`date +'\%Y-\%m-\%d'`; fn="/backups/mysql/mysql_$ts.sql.gz"; mysqldump --opt --events mysql | gzip > $fn
+15 3 * * * root find /backups/mysql -type f -mtime +{{ mysql_backup_keep_days }} -exec rm {} \\;

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -2,3 +2,4 @@
 
 postgresql_user: {name: "dpla", password: "changeme"}
 pg_max_connections: 50
+pg_backup_keep_days: 30

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -81,3 +81,19 @@
   sudo_user: postgres
   tags:
     - postgresql
+
+- name: Make sure that the backups directory exists
+  file: path=/backups state=directory owner=root group=root mode=0755
+  tags:
+    - postgresql
+- name: Make sure that the PostgreSQL backups directory exists
+  file: path=/backups/postgresql state=directory owner=postgres group=postgres mode=0770
+  tags:
+    - postgresql
+
+- name: Ensure state of crontab file
+  template: >-
+      src=etc_cron.d_backup-pg.j2 dest=/etc/cron.d/backup-pg
+      owner=root group=root mode=0644
+  tags:
+    - postgresql

--- a/ansible/roles/postgresql/templates/etc_cron.d_backup-pg.j2
+++ b/ansible/roles/postgresql/templates/etc_cron.d_backup-pg.j2
@@ -1,0 +1,5 @@
+
+1 3 * * * postgres ts=`date +'\%Y-\%m-\%d'`; fn="/backups/postgresql/api_$ts.sql"; pg_dump -c api > $fn
+2 3 * * * postgres ts=`date +'\%Y-\%m-\%d'`; fn="/backups/postgresql/dpla_portal_$ts.sql"; pg_dump -c dpla_portal > $fn
+3 3 * * * postgres ts=`date +'\%Y-\%m-\%d'`; fn="/backups/postgresql/postgres_$ts.sql"; pg_dump -c postgres > $fn
+5 3 * * * postgres find /backups/postgresql -type f -mtime +{{ pg_backup_keep_days }} -exec rm {} \\;


### PR DESCRIPTION
- Add daily dumps of MySQL and PostgreSQL databases.
- Update AWS Postfix 'generic' maps so that the postgres user
  can send crontab mail.
- Delete contentqa MySQL playbook because contentqa does not run
  MySQL.

I've run this against development, staging, and contentqa.
To test, you can do it against your development VM and check the next morning to see that it's produced dumpfiles.  Or look at staging ;-)
