### PR TITLE
Improve upgrades and reboots

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ $ ansible-playbook -i development -u vagrant \
   --private-key=$HOME/.vagrant.d/insecure_private_key dev_all.yml \
   -t users
 ```
-A second run to configure everything:
+Then some more invocations to configure everything:
 ```
+$ ansible-playbook -i development -u <your username in group_vars/all> \
+  playbooks/package_upgrade.yml
 $ ansible-playbook -i development -u <your username in group_vars/all> \
   dev_all.yml --extra-vars "initial_run=true"
 ```

--- a/ansible/playbooks/package_upgrade.yml
+++ b/ansible/playbooks/package_upgrade.yml
@@ -4,11 +4,7 @@
   hosts: all
   sudo: yes
   tasks:
-    - name: Update apt package index
-      apt: update_cache=yes
-      tags:
-        - packages
     - name: Upgrade apt packages
-      apt: upgrade=safe
+      apt: upgrade=safe update_cache=yes
       tags:
         - packages

--- a/ansible/playbooks/reboot.yml
+++ b/ansible/playbooks/reboot.yml
@@ -1,6 +1,7 @@
 ---
 
 # Reboot staging or production
+# Do not run this directly; use reboot_staging.yml or reboot_production.yml!
 
 - name: Instances that can be rebooted in parallel
   # TODO:  pre and post tasks that put cms sites and frontend

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -16,16 +16,6 @@
   tags:
     - networking
 
-- name: Update apt package index
-  apt: update_cache=yes
-  tags:
-    - packages
-
-- name: Upgrade apt packages
-  apt: upgrade=safe
-  tags:
-    - packages
-
 - name: Ensure correct time zone
   shell: >
       echo {{ iana_timezone }} > /etc/timezone; dpkg-reconfigure --frontend noninteractive tzdata
@@ -40,7 +30,8 @@
     - locale
 
 - name: Install packages
-  apt: pkg={{ item }} state=present
+  apt: >-
+    pkg="{{ item }}" state=present update_cache=yes
   with_items:
     - make
     - curl
@@ -50,6 +41,7 @@
     - munin-node
     - munin-plugins-extra
     - zlib1g-dev
+    - debian-goodies
   tags:
     - packages
     - munin


### PR DESCRIPTION
- Tidy up tasks in package_upgrade.yml
- Add warning comment to reboot.yml playbook
- Take package upgrade tasks out of the common playbook so that
  they don't always run
- Add debian-goodies package for 'checkrestart' utility
