### PR TITLE
Improve frontend private asset handling

### DIFF
--- a/ansible/roles/frontend/defaults/main.yml
+++ b/ansible/roles/frontend/defaults/main.yml
@@ -4,3 +4,4 @@ rails_env: development
 unicorn_worker_processes: 2
 frontend_use_local_source: false
 frontend_branch_or_tag: master
+frontend_use_restricted_assets: false

--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -1,25 +1,30 @@
 #!/bin/bash
 
 USE_VERSION=$1
+USE_ASSETS=${2:-unrestricted}
 export PATH=$HOME/.rbenv/bin:$PATH
 
 eval "`rbenv init -`"
-# Start ssh-agent and set environment variables.
-# Work-around for private GitHub repository in Gemfile.
-eval `ssh-agent`
-ssh-add $HOME/git_private_key
 
 cd $HOME/frontend
 
 rbenv shell $USE_VERSION
 
-bundle install
-bundle update dpla_frontend_assets
+if [[ "$USE_ASSETS" = "restricted" ]]; then
+    # Start ssh-agent and set environment variables.
+    # Work-around for private GitHub repository in Gemfile.
+    eval `ssh-agent`
+    ssh-add $HOME/git_private_key
+    bundle install
+    bundle update dpla_frontend_assets
+    # Variable set above by ssh-agent
+    kill $SSH_AGENT_PID
+else
+    bundle install --without dpla_branding
+fi
+
 rbenv rehash
 bundle exec rake assets:precompile
-
-# Variable set above by ssh-agent
-kill $SSH_AGENT_PID
 
 /usr/bin/rsync -ruptolg --checksum --delete --delay-updates \
     --exclude 'log' \

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -97,6 +97,7 @@
       src={{ github_private_key_path | default("~/.ssh/id_rsa") }}
       dest=/home/dpla/git_private_key
       owner=dpla group=dpla mode=0600
+  when: frontend_use_restricted_assets
   tags:
     - deployment
     - frontend
@@ -117,8 +118,9 @@
     - web
 
 - name: Build frontend app
-  script: >
+  script: >-
       build_frontend.sh {{ ruby_rbenv_version }}
+      {{ 'restricted' if frontend_use_restricted_assets else 'unrestricted' }}
   sudo_user: dpla
   tags:
     - deployment
@@ -156,6 +158,7 @@
 
 - name: Remove temporary private key for GitHub
   file: path=/home/dpla/git_private_key state=absent
+  when: frontend_use_restricted_assets
   tags:
     - deployment
     - frontend

--- a/ansible/roles/frontend/vars/development.yml.dist
+++ b/ansible/roles/frontend/vars/development.yml.dist
@@ -1,5 +1,7 @@
 ---
 
-# Uncomment this to use your local working copy for the frontend (portal)
-# (See Vagrantfile)
+## Uncomment this to use your local working copy for the frontend (portal)
+## (See Vagrantfile)
 # frontend_use_local_source: true
+## Uncomment this to use DPLA private frontend assets
+# frontend_use_restricted_assets: true


### PR DESCRIPTION
* Define new `frontend_use_restricted_assets` variable (boolean).
    * If True, copy private key; fetch private asset gem; build as normal; delete key.
    * If False, just build the frontend without the private asset gem.
* See dpla/frontend#45 for related frontend changes.