### PR TITLE
Upgrade Ansible for connection draining support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please install the following tools as documented on their websites:
 * [VirtualBox](https://www.virtualbox.org/) (Version 4.3)
 * [Vagrant](http://www.vagrantup.com/) (Version 1.6)
 * [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest/) (`vagrant plugin install vagrant-vbguest`)
-* [Ansible](http://www.ansible.com/) (Version 1.7 or greater; [installation instructions](http://docs.ansible.com/intro_installation.html))
+* [Ansible](http://www.ansible.com/) (Version 1.8) [installation instructions](http://docs.ansible.com/intro_installation.html)
 * Additional dependencies described in the `pip` requirements file (see below)
 
 ### Steps

--- a/ansible/playbooks/dbnodes.yml
+++ b/ansible/playbooks/dbnodes.yml
@@ -35,6 +35,9 @@
       tags:
         - database
         - packages
+    - name: Wait for connections to drain
+      wait_for: >-
+          host="{{ inventory_hostname }}" port="5984" state=drained timeout=60
   post_tasks:
     - name: Register instance with loadbalancer again
       local_action: ec2_elb

--- a/ansible/playbooks/elasticsearch.yml
+++ b/ansible/playbooks/elasticsearch.yml
@@ -40,6 +40,9 @@
         aws_secret_key: "{{ aws_secret_key }}"
         aws_region: "{{ aws_region }}"
         state: absent
+    - name: Wait for connections to drain
+      wait_for: >-
+          host="{{ inventory_hostname }}" port="9200" state=drained timeout=60
   post_tasks:
     - name: Wait for ES node to come back up
       sudo: false

--- a/ansible/playbooks/pre_post_tasks/api_pretasks.yml
+++ b/ansible/playbooks/pre_post_tasks/api_pretasks.yml
@@ -14,10 +14,7 @@
     aws_secret_key: "{{ aws_secret_key }}"
     aws_region: "{{ aws_region }}"
     state: absent
-# TODO:  when Ansible 1.8 is released, enable the following
-# and require Ansible 1.8.
-# - name: Wait for connections to drain
-#   sudo: false
-#   local_action: >-
-#       wait_for host="{{ inventory_hostname }}" port="{{ api_app_port }}"
-#       state=drained timeout=60
+- name: Wait for connections to drain
+  wait_for: >-
+    host="{{ inventory_hostname }}" port="{{ api_app_port }}"
+    state=drained timeout=60

--- a/ansible/playbooks/reboot_dbnodes.yml
+++ b/ansible/playbooks/reboot_dbnodes.yml
@@ -18,8 +18,9 @@
         aws_secret_key: "{{ aws_secret_key }}"
         aws_region: "{{ aws_region }}"
         state: absent
-    # TODO:  when Ansible 1.8 is released, check for connnection draining
-    # with `wait_for ... state=drained'.
+    - name: Wait for connections to drain
+      wait_for: >-
+          host="{{ inventory_hostname }}" port="5984" state=drained timeout=60
     - name: Reboot
       command: /sbin/shutdown -r now
       async: 0

--- a/ansible/playbooks/reboot_elasticsearch.yml
+++ b/ansible/playbooks/reboot_elasticsearch.yml
@@ -28,8 +28,9 @@
         aws_secret_key: "{{ aws_secret_key }}"
         aws_region: "{{ aws_region }}"
         state: absent
-    # TODO:  when Ansible 1.8 is released, check for connnection draining
-    # with `wait_for ... state=drained'.
+    - name: Wait for connections to drain
+      wait_for: >-
+          host="{{ inventory_hostname }}" port="9200" state=drained timeout=60
     - name: Reboot
       command: /sbin/shutdown -r now
       async: 0

--- a/ansible/playbooks/reboot_siteproxy.yml
+++ b/ansible/playbooks/reboot_siteproxy.yml
@@ -17,8 +17,9 @@
         aws_secret_key: "{{ aws_secret_key }}"
         aws_region: "{{ aws_region }}"
         state: absent
-    # TODO:  when Ansible 1.8 is released, check for connnection draining
-    # with `wait_for ... state=drained'.
+    - name: Wait for connections to drain
+      wait_for: >-
+          host="{{ inventory_hostname }}" port="80" state=drained timeout=60
     - name: Reboot
       command: /sbin/shutdown -r now
       async: 0

--- a/ansible/playbooks/siteproxy.yml
+++ b/ansible/playbooks/siteproxy.yml
@@ -31,6 +31,9 @@
         aws_secret_key: "{{ aws_secret_key }}"
         aws_region: "{{ aws_region }}"
         state: absent
+    - name: Wait for connections to drain
+      wait_for: >-
+          host="{{ inventory_hostname }}" port="80" state=drained timeout=60
   post_tasks:
     - name: Wait for site proxy node to come back up
       sudo: false

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -37,6 +37,7 @@
     - curl
     - sysstat
     - python-httplib2
+    - python-psutil
     - ntp
     - munin-node
     - munin-plugins-extra


### PR DESCRIPTION
- Require Ansible 1.8
- For reboots and loadbalancer pool operations, wait for connections
  to drain before proceeding.

The 'state=drained' argument to wait_for is new with Ansible 1.8.

Allowing connections to drain means less likelihood of client errors.

I've tested this against my VMs and staging.

If you want to try this, there are two things to be aware of:
* You'll need to run the `common` role to install a new python package, `psutil`, on the inventory hosts.
* You'll have to comment out the deb package source in `ansible/roles/dbnode/templates/cloudand.list.j2` because of an unrelated issue with Cloudant yanking the BigCouch package from its former location.  Comment this out if you run the `common_staging.yml` or `dbnodes_staging.yml` playbooks.  If you run `common_staging.yml` you have to comment out that file on the servers, not the template file.  This is a completely separate issue that I'll have to address in another PR.
