### PR TITLE
Fix BigCouch installation

### DIFF
--- a/ansible/roles/dbnode/tasks/main.yml
+++ b/ansible/roles/dbnode/tasks/main.yml
@@ -5,22 +5,54 @@
   tags:
   - database
 
-- name: Add cloudant package list
-  template: src=cloudant.list.j2 dest=/etc/apt/sources.list.d/cloudant.list
+- name: Ensure that runit is installed
+  apt: name=runit state=present
   tags:
     - packages
     - database
 
-- name: Update apt package index for bigcouch
-  apt: update_cache=yes
+- name: Figure out if the Spidermonkey package has to be downloaded
+  stat: path=/var/tmp/libmozjs185-cloudant_1.8.5-cloudant1_amd64.deb
+  register: libmozjs_deb
   tags:
     - packages
     - database
 
-- name: Install packages
-  apt: pkg={{ item }} state=present force=yes
-  with_items:
-    - bigcouch
+- name: Figure out if the BigCouch package has to be downloaded
+  stat: path=/var/tmp/bigcouch_0.4.2-1_amd64.deb
+  register: bigcouch_deb
+  tags:
+    - packages
+    - database
+
+- name: "Download Spidermonkey package, if necessary"
+  get_url: >-
+    url="https://s3.amazonaws.com/dpla-automation-download/libmozjs185-cloudant_1.8.5-cloudant1_amd64.deb"
+    dest="/var/tmp/libmozjs185-cloudant_1.8.5-cloudant1_amd64.deb"
+    sha256sum=fa874ac83136e26a0596066e05f143c0548a11bbf7f928e3b9c97ce129336e9f
+  when: not libmozjs_deb.stat.exists
+  tags:
+    - packages
+    - database
+
+- name: "Download bigcouch package, if necessary"
+  get_url: >-
+    url="https://s3.amazonaws.com/dpla-automation-download/bigcouch_0.4.2-1_amd64.deb"
+    dest="/var/tmp/bigcouch_0.4.2-1_amd64.deb"
+    sha256sum=f15bb3a3ebc7e5b62a9d54b7965f569670b2ee03c3c026055bee7f3b82c41d2d
+  when: not bigcouch_deb.stat.exists
+  tags:
+    - packages
+    - database
+
+- name: Ensure installation of Spidermonkey javascript engine
+  apt: deb=/var/tmp/libmozjs185-cloudant_1.8.5-cloudant1_amd64.deb
+  tags:
+    - packages
+    - database
+
+- name: Ensure installation of BigCouch
+  apt: deb=/var/tmp/bigcouch_0.4.2-1_amd64.deb
   tags:
     - packages
     - database

--- a/ansible/roles/dbnode/templates/cloudant.list.j2
+++ b/ansible/roles/dbnode/templates/cloudant.list.j2
@@ -1,1 +1,0 @@
-deb http://packages.cloudant.com/ubuntu precise main


### PR DESCRIPTION
Provide .deb package files to download, because the packages that we
used to fetch from the Cloudant repository have been removed.

Though we're going to stop using BigCouch soon, we have to fix this so that new installations of dev VMs with the legacy system don't fail.
