### PR TITLE
Ensure that Cloudant package list has been removed

### DIFF
--- a/ansible/roles/dbnode/tasks/main.yml
+++ b/ansible/roles/dbnode/tasks/main.yml
@@ -5,6 +5,12 @@
   tags:
   - database
 
+- name: Make sure that our old Cloudant package list has been removed
+  file: path=/etc/apt/sources.list.d/cloudant.list state=absent
+  tags:
+    - packages
+    - database
+
 - name: Ensure that runit is installed
   apt: name=runit state=present
   tags:


### PR DESCRIPTION
If the old apt source list file is still present, it will cause
errors with package upgrades.  The file used to be necessary for our
BigCouch installation and might be present on systems that have existed
before we removed it.