### PR TITLE
Make PostgreSQL maintenance playbooks more flexible

### DIFF
--- a/ansible/playbooks/pg_maintenance_off.yml
+++ b/ansible/playbooks/pg_maintenance_off.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Take API out of maintenance mode
+  hosts: api
+  sudo: true
+  tasks:
+    - name: Remove maintenance.yml file
+      file: >-
+        path=/srv/www/api/tmp/maintenance.yml
+        state=absent
+
+- name: Take frontend out of maintenance mode
+  hosts: frontend
+  sudo: true
+  tasks:
+    - name: Remove maintenance.yml file
+      file: >-
+        path=/srv/www/frontend/tmp/maintenance.yml
+        state=absent
+
+- include: clear_proxy_cache.yml

--- a/ansible/playbooks/pg_maintenance_on.yml
+++ b/ansible/playbooks/pg_maintenance_on.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Put frontend into maintenance mode
+  hosts: frontend
+  sudo: true
+  tasks:
+    - name: Deploy turnout maintenance.yml file
+      copy: >-
+        src=../files/turnout_postgres_maintenance.yml
+        dest=/srv/www/frontend/tmp/maintenance.yml
+        owner=root group=root mode=0644
+
+- name: Put API into maintenance mode
+  hosts: api
+  sudo: true
+  tasks:
+    - name: Deploy turnout maintenance.yml file
+      copy: >-
+        src=../files/turnout_postgres_maintenance.yml
+        dest=/srv/www/api/tmp/maintenance.yml
+        owner=root group=root mode=0644
+
+- include: clear_proxy_cache.yml

--- a/ansible/playbooks/reboot_postgresql.yml
+++ b/ansible/playbooks/reboot_postgresql.yml
@@ -1,24 +1,6 @@
 ---
 
-- name: Put frontend into maintenance mode
-  hosts: frontend
-  sudo: true
-  tasks:
-    - name: Deploy turnout maintenance.yml file
-      copy: >-
-        src=../files/turnout_postgres_maintenance.yml
-        dest=/srv/www/frontend/tmp/maintenance.yml
-        owner=root group=root mode=0644
-
-- name: Put API into maintenance mode
-  hosts: api
-  sudo: true
-  tasks:
-    - name: Deploy turnout maintenance.yml file
-      copy: >-
-        src=../files/turnout_postgres_maintenance.yml
-        dest=/srv/www/api/tmp/maintenance.yml
-        owner=root group=root mode=0644
+- include: pg_maintenance_on.yml
 
 - name: Reboot PostgreSQL server
   hosts: postgresql_dbs
@@ -35,20 +17,4 @@
         wait_for host="{{ inventory_hostname }}"
         port=5432 delay=40 timeout=600
 
-- name: Take API out of maintenance mode
-  hosts: api
-  sudo: true
-  tasks:
-    - name: Remove maintenance.yml file
-      file: >-
-        path=/srv/www/api/tmp/maintenance.yml
-        state=absent
-
-- name: Take frontend out of maintenance mode
-  hosts: frontend
-  sudo: true
-  tasks:
-    - name: Remove maintenance.yml file
-      file: >-
-        path=/srv/www/frontend/tmp/maintenance.yml
-        state=absent
+- include: pg_maintenance_off.yml


### PR DESCRIPTION
Allow for manual initiation and disabling of maintenance mode outside of a reboot.

Also add clearing of proxy cache, which was necessary but missing.

This is a minor change I had hanging around and had forgotten about until now, but will be convenient to have merged before making some upcoming changes to production.  It makes it more convenient to put the frontend into maintenance mode for something other than a server reboot.  It also fixes the fact that the proxy cache was not being cleared.
