### PR TITLE
Exhibitions: deploy master by default

### DIFF
--- a/ansible/roles/omeka/defaults/main.yml
+++ b/ansible/roles/omeka/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-exhibitions_branch_or_tag: "v18.0.2"
+exhibitions_branch_or_tag: "master"
 exhibitions_api_key: "{{ api_key }}"
 
 # PHP-FPM tuning parameters


### PR DESCRIPTION
Minor change that's caused us some snags in the past.