### PR TITLE
Add standalone ingestion app deployment playbooks

### DIFF
--- a/ansible/playbooks/deploy_ingestion_app.yml
+++ b/ansible/playbooks/deploy_ingestion_app.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Gather inventory facts in case playbook is run standalone
+  hosts: all
+
+- name: Deploy Ingestion Application
+  hosts:
+    - ingestion_app
+    - worker
+  sudo: yes
+  tasks:
+    - include: ../roles/ingestion_app/tasks/deploy.yml
+  handlers:
+    - include: ../roles/ingestion_app/handlers/main.yml
+  vars_files:
+    - "../vars/{{ level }}.yml"
+    - "../roles/ingestion_app/defaults/main.yml"
+    - "../roles/ingestion_app/vars/{{ level }}.yml"

--- a/ansible/playbooks/deploy_ingestion_app_development.yml
+++ b/ansible/playbooks/deploy_ingestion_app_development.yml
@@ -1,0 +1,3 @@
+---
+
+- include: deploy_ingestion_app.yml level=development

--- a/ansible/playbooks/deploy_ingestion_app_production.yml
+++ b/ansible/playbooks/deploy_ingestion_app_production.yml
@@ -1,0 +1,3 @@
+---
+
+- include: deploy_ingestion_app.yml level=production

--- a/ansible/playbooks/deploy_ingestion_app_staging.yml
+++ b/ansible/playbooks/deploy_ingestion_app_staging.yml
@@ -1,0 +1,3 @@
+---
+
+- include: deploy_ingestion_app.yml level=staging


### PR DESCRIPTION
This adds discrete playbooks for deploying the ingestion application, without performing the role's other provisioning tasks.