### PR TITLE
Fix incorrect rsync options for deployments

### DIFF
--- a/ansible/roles/api/files/build_api.sh
+++ b/ansible/roles/api/files/build_api.sh
@@ -12,7 +12,7 @@ rbenv shell $USE_VERSION
 bundle install
 rbenv rehash
 
-/usr/bin/rsync -ruptolg --checksum --delete --delay-updates \
+/usr/bin/rsync -rptolg --checksum --delete --delay-updates \
     --exclude 'var/log' \
     --exclude 'tmp' \
     --exclude '.git' \

--- a/ansible/roles/api/files/copy_local_app.sh
+++ b/ansible/roles/api/files/copy_local_app.sh
@@ -13,7 +13,7 @@ if [ ! -d /home/dpla/api ]; then
 	mkdir /home/dpla/api
 fi
 
-rsync -ruptl --delete --checksum \
+rsync -rptl --delete --checksum \
     --exclude 'var/log' --exclude 'tmp' --exclude 'vendor/bundle' \
     /api_dev/ /home/dpla/api
 if [ $? -ne 0 ]; then

--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -21,7 +21,7 @@ bundle exec rake assets:precompile
 # Variable set above by ssh-agent
 kill $SSH_AGENT_PID
 
-/usr/bin/rsync -ruptolg --checksum --delete --delay-updates \
+/usr/bin/rsync -rptogl --checksum --delete --delay-updates \
     --exclude 'log' \
     --exclude 'tmp' \
     --exclude '.git' \

--- a/ansible/roles/frontend/files/copy_local_app.sh
+++ b/ansible/roles/frontend/files/copy_local_app.sh
@@ -13,7 +13,7 @@ if [ ! -d /home/dpla/frontend ]; then
 	mkdir /home/dpla/frontend
 fi
 
-rsync -ruptl --delete --checksum \
+rsync -rptl --delete --checksum \
     --exclude 'log' --exclude 'tmp' --exclude 'vendor/assets' \
     --exclude 'public/uploads' \
     /frontend_dev/ /home/dpla/frontend

--- a/ansible/roles/ingestion_app/files/build_ingestion.sh
+++ b/ansible/roles/ingestion_app/files/build_ingestion.sh
@@ -18,7 +18,7 @@ rbenv global $use_version
 bundle install || exit 1
 rbenv rehash
 
-/usr/bin/rsync -ruptolg --checksum --delete --delay-updates \
+/usr/bin/rsync -rptolg --checksum --delete --delay-updates \
     --exclude 'log' \
     --exclude 'tmp' \
     --exclude '.git' \

--- a/ansible/roles/ingestion_app/files/copy_local_app.sh
+++ b/ansible/roles/ingestion_app/files/copy_local_app.sh
@@ -21,11 +21,11 @@ if [ ! -d /home/dpla/heidrun ]; then
     mkdir /home/dpla/heidrun
 fi
 
-rsync -ruptl --delete --checksum \
+rsync -rptl --delete --checksum \
     --exclude '.git*' /krikri/ /home/dpla/krikri \
     || exit 1
 
-rsync -ruptl --delete --checksum \
+rsync -rptl --delete --checksum \
     --exclude '.git*' --exclude 'log' \
     /heidrun/ /home/dpla/heidrun \
     || exit 1

--- a/ansible/roles/wordpress/files/build_wordpress_local.sh
+++ b/ansible/roles/wordpress/files/build_wordpress_local.sh
@@ -6,7 +6,7 @@ rsync=/usr/bin/rsync
 
 cd $HOME
 
-$rsync -ruptoglv --delete --checksum \
+$rsync -rptl --delete --checksum \
     --exclude '.git' \
     --exclude 'wp-config.php' \
     --exclude 'wp-content/uploads' \

--- a/ansible/roles/wordpress/files/sync_to_siteroot.sh
+++ b/ansible/roles/wordpress/files/sync_to_siteroot.sh
@@ -3,7 +3,7 @@
 
 rsync=/usr/bin/rsync
 
-$rsync -ruptolg --checksum --delete --delay-updates \
+$rsync -rptogl --checksum --delete --delay-updates \
     --exclude 'wp-content/uploads' \
     --exclude 'wp-config.php' \
     --exclude '.git' \


### PR DESCRIPTION
Rsync is used in various deployment scripts to copy files between
source, build, and target directories.

When rsync is called with `--checksum`, the `-u` option should
not be passed, because this overrides the desired checksum
behavior.

This was causing  files modified on the server more recently than their
sources in the local development working copy to fail to be overwritten.
In at least one case, we modify a Gemfile in the server's build
directory after it's copied there, which results in its timestamp being
newer than that of the source.  The next time it's deployed, it will
fail to be copied if the `-u` switch is given to rsync.

Here is an example of rsync's behavior with and without `-u`, combined
with `checksum`:

```bash
  $ mkdir a b
  $ echo line1 > a/file
  $ rsync -a a/ b
  $ cat b/file
  line1
  $ echo line2 >> b/file
  $ rsync -ruptv --checksum a/ b
  # b/file is _not_ updated to match a/file ...
  $ cat b/file
  line1
  line2
  $ rsync -rptv --checksum a/ b
  # b/file _is_ updated to match a/file ...
  $ cat b/file
  line1
```

This change has been tested with local deployments of api, frontend,
ingestion_app, and wordpress, by modifying files on the target host
and observing that they get overwritten.