### PR TITLE
Improve cooperation between local and git deployments

### DIFF
--- a/ansible/roles/api/files/copy_local_app.sh
+++ b/ansible/roles/api/files/copy_local_app.sh
@@ -9,15 +9,15 @@ if [ ! -d /api_dev ]; then
 	exit 1
 fi
 
-if [ ! -d /home/dpla/api ]; then
-	mkdir /home/dpla/api
+if [ ! -d /home/dpla/api-local ]; then
+	mkdir /home/dpla/api-local
 fi
 
 rsync -rptl --delete --checksum \
     --exclude 'var/log' --exclude 'tmp' --exclude 'vendor/bundle' \
-    /api_dev/ /home/dpla/api
+    /api_dev/ /home/dpla/api-local
 if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-chown -Rh dpla:dpla /home/dpla/api
+chown -Rh dpla:dpla /home/dpla/api-local

--- a/ansible/roles/api/tasks/deploy.yml
+++ b/ansible/roles/api/tasks/deploy.yml
@@ -8,11 +8,13 @@
     - deployment
     - web
 
+# Clear these out prior to copying and symlinking below
+- file: path=/home/dpla/api state=absent
 
-- name: Check out api (platform) app from its repository
+- name: Check out api (platform) app from its repository (git)
   git: >
       repo=https://github.com/dpla/platform.git
-      dest=/home/dpla/api
+      dest=/home/dpla/api-git
       version={{ api_branch_or_tag | default("master") }}
   sudo_user: dpla
   when: not api_use_local_source
@@ -22,7 +24,12 @@
     - api_deployment
     - web
 
-- name: Check out api (platform) app from mounted directory
+# Symlink to the build directory, to allow local and git builds to coexist neatly
+# 1. Git deployment ...
+- file: src=/home/dpla/api-git dest=/home/dpla/api state=link
+  when: not api_use_local_source
+
+- name: Check out api (platform) app from mounted directory (local)
   script: copy_local_app.sh
   when: api_use_local_source
   tags:
@@ -30,6 +37,11 @@
     - api
     - api_deployment
     - web
+
+# Symlink, as above
+# 2. Local filesystem deployment ...
+- file: src=/home/dpla/api-local dest=/home/dpla/api state=link
+  when: api_use_local_source
 
 - name: Update api app database configuration
   template: >

--- a/ansible/roles/frontend/files/copy_local_app.sh
+++ b/ansible/roles/frontend/files/copy_local_app.sh
@@ -9,16 +9,16 @@ if [ ! -d /frontend_dev ]; then
 	exit 1
 fi
 
-if [ ! -d /home/dpla/frontend ]; then
-	mkdir /home/dpla/frontend
+if [ ! -d /home/dpla/frontend-local ]; then
+	mkdir /home/dpla/frontend-local
 fi
 
 rsync -rptl --delete --checksum \
     --exclude 'log' --exclude 'tmp' --exclude 'vendor/assets' \
     --exclude 'public/uploads' \
-    /frontend_dev/ /home/dpla/frontend
+    /frontend_dev/ /home/dpla/frontend-local
 if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-chown -Rh dpla:dpla /home/dpla/frontend
+chown -Rh dpla:dpla /home/dpla/frontend-local

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -8,10 +8,13 @@
     - frontend_deployment
     - web
 
+# Clear this out prior to copying and symlinking below
+- file: path=/home/dpla/frontend state=absent
+
 - name: Check out frontend app from its repository
   git: >
       repo=https://github.com/dpla/frontend.git
-      dest=/home/dpla/frontend
+      dest=/home/dpla/frontend-git
       version={{ frontend_branch_or_tag }}
   sudo_user: dpla
   when: not frontend_use_local_source
@@ -21,6 +24,11 @@
     - frontend_deployment
     - web
 
+# Symlink to the build directory, to allow local and git builds to coexist neatly
+# 1. For a git deployment ...
+- file: src=/home/dpla/frontend-git dest=/home/dpla/frontend state=link
+  when: not frontend_use_local_source
+
 - name: Check out frontend app from mounted directory
   script: copy_local_app.sh
   when: frontend_use_local_source
@@ -29,6 +37,11 @@
     - frontend
     - frontend_deployment
     - web
+
+# Symlink (see above)
+# 2. For a local deployment ...
+- file: src=/home/dpla/frontend-local dest=/home/dpla/frontend state=link
+  when: frontend_use_local_source
 
 - name: Update frontend app database configuration
   template: >

--- a/ansible/roles/ingestion_app/files/copy_local_app.sh
+++ b/ansible/roles/ingestion_app/files/copy_local_app.sh
@@ -22,12 +22,12 @@ fi
 if [ ! -d /home/dpla/krikri ]; then
     mkdir /home/dpla/krikri
 fi
-if [ ! -d /home/dpla/heidrun ]; then
-    mkdir /home/dpla/heidrun
+if [ ! -d /home/dpla/heidrun-local ]; then
+    mkdir /home/dpla/heidrun-local
 fi
 
-if [ ! -d /home/dpla/heidrun-mappings ]; then
-    mkdir /home/dpla/heidrun-mappings
+if [ ! -d /home/dpla/heidrun-mappings-local ]; then
+    mkdir /home/dpla/heidrun-mappings-local
 fi
 
 rsync -rptl --delete --checksum \
@@ -36,10 +36,10 @@ rsync -rptl --delete --checksum \
 
 rsync -rptl --delete --checksum \
     --exclude '.git*' --exclude 'log' \
-    /heidrun/ /home/dpla/heidrun \
+    /heidrun/ /home/dpla/heidrun-local \
     || exit 1
 
 rsync -rptl --delete --checksum \
     --exclude '.git*' --exclude 'README.md' --exclude 'LICENSE' \
-    /heidrun-mappings/ /home/dpla/heidrun-mappings \
+    /heidrun-mappings/ /home/dpla/heidrun-mappings-local \
     || exit 1

--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -73,11 +73,15 @@
   tags:
     - deployment
 
+# Clear these out prior to copying and symlinking below
+- file: path=/home/dpla/heidrun state=absent
+- file: path=/home/dpla/heidrun-mappings state=absent
+
 # Copy files to build, network installation
 - name: Check out ingestion app from its repository (not using local source)
   git: >-
       repo=https://github.com/dpla/heidrun.git
-      dest=/home/dpla/heidrun
+      dest=/home/dpla/heidrun-git
       version={{ heidrun_branch_or_tag }}
   sudo_user: dpla
   when: not ingestion_use_local_source
@@ -87,12 +91,19 @@
 - name: Check out mappings from their repository (not using local source)
   git: >-
       repo=https://github.com/dpla/heidrun-mappings.git
-      dest=/home/dpla/heidrun-mappings
+      dest=/home/dpla/heidrun-mappings-git
       version={{ heidrun_mappings_branch_or_tag }}
   sudo_user: dpla
   when: not ingestion_use_local_source
   tags:
     - deployment
+
+# Symlink to the build directories, to allow local and git builds to coexist neatly
+# 1. For a git deployment ...
+- file: src=/home/dpla/heidrun-git dest=/home/dpla/heidrun state=link
+  when: not ingestion_use_local_source
+- file: src=/home/dpla/heidrun-mappings-git dest=/home/dpla/heidrun-mappings state=link
+  when: not ingestion_use_local_source
 
 # Copy files to build, local filesystem installation
 - name: Check out ingestion app from mounted directory (using local source)
@@ -101,6 +112,14 @@
   when: ingestion_use_local_source
   tags:
     - deployment
+
+# Symlinking, as above
+# 2. For a local filesystem deployment ...
+- file: src=/home/dpla/heidrun-local dest=/home/dpla/heidrun state=link
+  when: ingestion_use_local_source
+- file: src=/home/dpla/heidrun-mappings-local dest=/home/dpla/heidrun-mappings state=link
+  when: ingestion_use_local_source
+
 - name: Finesse Heidrun Gemfile to use local Krikri (using local source)
   lineinfile: >-
     dest=/home/dpla/heidrun/Gemfile


### PR DESCRIPTION
Fix the population of build directories during deployments in the
development environment to avoid errors in some cases when switching
between local-filesystem and git deployments.

This also preserves separate directories for git and local build
directories so that they can be better analyzed independently of
one-another and so that they should be faster to rsync upon subsequent
deployments.