### PR TITLE
Add param for controlling Munin alert sending

### DIFF
--- a/ansible/roles/munin_master/defaults/main.yml
+++ b/ansible/roles/munin_master/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+
+# `munin_always_send' governs whether to send repeated, redundant alert
+# messages even if the alert's state has not changed.
+munin_always_send: false
+# `munin_alert_priorities' governs which sorts of alert messages to send
+# if you want `munin_always_send' to be true.
+munin_always_send_priorities: "warning critical"

--- a/ansible/roles/munin_master/templates/munin.conf.j2
+++ b/ansible/roles/munin_master/templates/munin.conf.j2
@@ -56,12 +56,16 @@ includedir /etc/munin/munin-conf.d
 #contact.nagios.command /usr/bin/send_nsca nagios.host.comm -c /etc/nsca.conf
 {% if munin_notification_email_recipient is defined %}
 contact.techstaff.command mail -s "[munin: ${var:group} - ${var:host}] ${var:graph_title}" {{ munin_notification_email_recipient }}
-contact.techstaff.always_send warning critical
+{% if munin_always_send %}
+contact.techstaff.always_send {{ munin_always_send_priorities }}
+{% endif %}
 {% endif %}
 
 {% if slack_webhook_url is defined %}
 contact.slack.command MUNIN_SERVICESTATE="${var:worst}" MUNIN_HOST="${var:host}" MUNIN_SERVICE="${var:graph_title}" MUNIN_GROUP=${var:group} /usr/local/bin/notify_slack_munin
-contact.slack.always_send warning critical
+{% if munin_always_send %}
+contact.slack.always_send {{ munin_always_send_priorities }}
+{% endif %}
 # note: This has to be on one line for munin to parse properly
 contact.slack.text ${if:cfields \u000A* CRITICALs:${loop<,>:cfields  ${var:label} is ${var:value} (outside range [${var:crange}])${if:extinfo : ${var:extinfo}}}.}${if:wfields \u000A* WARNINGs:${loop<,>:wfields  ${var:label} is ${var:value} (outside range [${var:wrange}])${if:extinfo : ${var:extinfo}}}.}${if:ufields \u000A* UNKNOWNs:${loop<,>:ufields  ${var:label} is ${var:value}${if:extinfo : ${var:extinfo}}}.}${if:fofields \u000A* OKs:${loop<,>:fofields  ${var:label} is ${var:value}${if:extinfo : ${var:extinfo}}}.}
 {% endif %}


### PR DESCRIPTION
Add munin_always_send and munin_always_send_priorities, which govern
whether Munin sends repeated alert messages if the alert's state has
not changed.