### PR TITLE
Install php5-cli for common_php role [fixes #7788]

### DIFF
--- a/ansible/roles/common_php/tasks/main.yml
+++ b/ansible/roles/common_php/tasks/main.yml
@@ -4,6 +4,7 @@
   apt: >-
       pkg="{{ item }}" state=present force=yes
   with_items:
+    - php5-cli
     - php5-curl
     - php5-fpm
     - php5-imagick


### PR DESCRIPTION
Omeka requires php5-cli to run background jobs; this is not adequately represented in Omeka's documentation.

This fixes an issue where the Omeka CSV Import plugin was not working properly.