### PR TITLE
Set Linux kernel params for memory overcommitment

### DIFF
--- a/ansible/group_vars/ingestion
+++ b/ansible/group_vars/ingestion
@@ -1,0 +1,2 @@
+# See roles/common/defaults/main.yml
+kernel_vm_overcommit_memory: 2

--- a/ansible/group_vars/ingestion_app
+++ b/ansible/group_vars/ingestion_app
@@ -1,0 +1,2 @@
+# See roles/common/defaults/main.yml
+kernel_vm_overcommit_memory: 2

--- a/ansible/ingestion
+++ b/ansible/ingestion
@@ -1,5 +1,5 @@
 dev1 ansible_ssh_host=192.168.50.7
-dev2 ansible_ssh_host=192.168.50.8 tomcat_max_mem_mb=256 tomcat_init_mem_mb=256
+dev2 ansible_ssh_host=192.168.50.8 tomcat_max_mem_mb=256 tomcat_init_mem_mb=256 kernel_vm_overcommit_ratio=95
 
 [loadbalancer]
 dev1

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -2,3 +2,7 @@
 
 # This default value is for development:
 munin_master_ipaddr: 192.168.50.6
+
+# Linux kernel parameters
+kernel_vm_overcommit_memory: 0
+kernel_vm_overcommit_ratio: 90

--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -8,3 +8,8 @@
 
 - name: restart munin node
   service: name=munin-node state=reloaded
+
+# The procps service is invoked like this to apply kernel perameters with
+# sysctl.
+- name: start procps
+  service: name=procps state=started

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Ensure correct kernel overcommitment settings
+  template: >-
+    src=etc_sysctl.d_60-overcommit.conf.j2 dest=/etc/sysctl.d/60-overcommit.conf
+    mode=0644 owner=root group=root
+  notify:
+    - start procps
+  tags:
+    - kernel
+
 - name: Set hostname
   hostname: name={{ inventory_hostname }}
   tags:

--- a/ansible/roles/common/templates/etc_sysctl.d_60-overcommit.conf.j2
+++ b/ansible/roles/common/templates/etc_sysctl.d_60-overcommit.conf.j2
@@ -1,0 +1,2 @@
+vm.overcommit_memory = {{ kernel_vm_overcommit_memory }}
+vm.overcommit_ratio = {{ kernel_vm_overcommit_ratio }}


### PR DESCRIPTION
See http://www.win.tue.nl/~aeb/linux/lk/lk-9.html
See http://www.etalabs.net/overcommit.html

The default for vm.overcommit_memory is the Linux kernel default of 0,
for the standard heuristic.  The ingestion servers use 2, to allow them
to go a little crazier with malloc and, I suppose, potentially forking
new processes.

The development VM `dev2` is given an overcommit_ratio of 95 to allow it to allocate a little more memory, because it doesn't have a swap partition.  (Some memory is reserved for kernel buffer and block caches.)  I'm not sure if this is the best setting, but let's see how it works.
