### PR TITLE
Add `elasticsearch` to ingestion app settings

### DIFF
--- a/ansible/roles/ingestion_app/templates/config_settings.local.yml.j2
+++ b/ansible/roles/ingestion_app/templates/config_settings.local.yml.j2
@@ -18,6 +18,10 @@ marmotta:
   record_container: '{{ marmotta_base }}/ldp/original_record'
   item_container: '{{ marmotta_base }}/ldp/items'
 
+elasticsearch:
+  host: '{{ es_cluster_loadbal }}:9200'
+  index_name: 'dpla_alias'
+
 prov:
   activity: 'activity'
 


### PR DESCRIPTION
Add an `elasticsearch` section to Heidrun's settings.local.yml

This will need to be in-place before https://github.com/dpla/KriKri/pull/131 is merged in and deployed.
