### PR TITLE
Marmotta: disable LDCache module

### DIFF
--- a/ansible/roles/marmotta/templates/system-config.properties.j2
+++ b/ansible/roles/marmotta/templates/system-config.properties.j2
@@ -177,3 +177,4 @@ user.admin.roles = editor
 user.admin.roles = manager
 user.admin.roles = user
 marmotta.home = {{ marmotta_home }}
+ldcache.enabled = false


### PR DESCRIPTION
Disables the LDCache module, which attempts to fetch remote resources through dereferencing. This will reduce the number of outgoing requests from our Marmotta instance, and may speed up save and query performance.

LDCache is known to at least have some performance implications, as described [here](https://github.com/apache/marmotta/blob/develop/platform/ldcache/marmotta-ldcache-common/src/main/resources/config-defaults.properties#L23-L25).
