### PR TITLE
[marmotta] Set up custom log rotation for Nginx

### DIFF
--- a/ansible/roles/marmotta/tasks/main.yml
+++ b/ansible/roles/marmotta/tasks/main.yml
@@ -39,6 +39,13 @@
       owner=root group=root mode=0644
   notify: restart nginx
 
+- name: Make sure nginx logs get rotated
+  template: >-
+      src="etc_logrotate.d_nginx.j2" dest="/etc/logrotate.d/nginx"
+      owner=root group=root mode=0644
+  tags:
+    - logrotate
+
 - name: Symlink webserver virtual host for Marmotta
   file: >-
       src="/etc/nginx/sites-available/marmotta"

--- a/ansible/roles/marmotta/templates/etc_logrotate.d_nginx.j2
+++ b/ansible/roles/marmotta/templates/etc_logrotate.d_nginx.j2
@@ -1,0 +1,18 @@
+/var/log/nginx/*.log {
+    daily
+    missingok
+    rotate 7
+    compress
+    delaycompress
+    notifempty
+    create 0640 www-data adm
+    sharedscripts
+    prerotate
+            if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+                    run-parts /etc/logrotate.d/httpd-prerotate; \
+            fi \
+    endscript
+    postrotate
+            [ -s /run/nginx.pid ] && kill -USR1 `cat /run/nginx.pid`
+    endscript
+}


### PR DESCRIPTION
The default logrotate configuration for Nginx was not rotating the logs
quickly enough to address some disk space issues we have been seeing.
This changes the Nginx logs to rotate daily, with 7 days of logs being
retained.