### PR TITLE
Improve Tomcat logfile rotation

### DIFF
--- a/ansible/roles/tomcat_common/defaults/main.yml
+++ b/ansible/roles/tomcat_common/defaults/main.yml
@@ -4,3 +4,13 @@ tomcat_admin_username: tcadmin
 tomcat_admin_password: changeme
 tomcat_max_mem_mb: 256
 tomcat_init_mem_mb: 256
+
+# logfile ages, in days:
+# ... "catalina" logs are rotated by logrotate:
+tomcat_catalina_log_age: 7
+# ... AccessLogValve logs are governed by directives in server.xml.
+# The ".log" logs are pruned by a cron.daily script that comes with
+# the Ubuntu tomcat7 package, and the access_log logs have to be
+# pruned by our own cron job.  See etc_default_tomcat7.j2 and
+# etc_logrotate.d_tomcat7.j2.
+tomcat_accesslogvalve_log_age: 7

--- a/ansible/roles/tomcat_common/tasks/main.yml
+++ b/ansible/roles/tomcat_common/tasks/main.yml
@@ -31,3 +31,17 @@
     - server.xml
     - web.xml
   notify: restart tomcat
+
+- name: Ensure that Tomcat "catalina" logs are rotated correctly
+  template: >-
+    src=etc_logrotate.d_tomcat7.j2 dest=/etc/logrotate.d/tomcat7
+    mode=0644 owner=root group=root
+  tags:
+    - logs
+
+- name: Ensure that Tomcat AccessLogValve logs are pruned
+  template: >-
+    src=etc_cron.d_prune-tomcat-access-logs.j2 dest=/etc/cron.d/prune-tomcat-access-logs
+    mode=0644 owner=root group=root
+  tags:
+    - logs

--- a/ansible/roles/tomcat_common/templates/etc_cron.d_prune-tomcat-access-logs.j2
+++ b/ansible/roles/tomcat_common/templates/etc_cron.d_prune-tomcat-access-logs.j2
@@ -1,0 +1,2 @@
+
+1 0 * * * tomcat7 find /var/log/tomcat7 -name \*localhost_access_log\* -mtime +{{ tomcat_accesslogvalve_log_age }} -exec rm {} \\;

--- a/ansible/roles/tomcat_common/templates/etc_default_tomcat7.j2
+++ b/ansible/roles/tomcat_common/templates/etc_default_tomcat7.j2
@@ -32,7 +32,7 @@ JAVA_OPTS="-Djava.awt.headless=true -Xmx{{ tomcat_max_mem_mb }}m -Xms{{ tomcat_i
 #TOMCAT7_SECURITY=no
 
 # Number of days to keep logfiles in /var/log/tomcat7. Default is 14 days.
-#LOGFILE_DAYS=14
+LOGFILE_DAYS={{ tomcat_accesslogvalve_log_age }}
 # Whether to compress logfiles older than today's
 #LOGFILE_COMPRESS=1
 

--- a/ansible/roles/tomcat_common/templates/etc_logrotate.d_tomcat7.j2
+++ b/ansible/roles/tomcat_common/templates/etc_logrotate.d_tomcat7.j2
@@ -1,0 +1,8 @@
+/var/log/tomcat7/catalina.out {
+  copytruncate
+  daily
+  rotate {{ tomcat_catalina_log_age }}
+  compress
+  missingok
+  create 640 tomcat7 adm
+}


### PR DESCRIPTION
- Prune access_log logs that were not being deleted
- Add parameters for age of "catalina" and AccessLogValve logs
- Change "catalina" logs to rotate daily, instead of weekly