### PR TITLE
Assign kernel overcommit setting on workers

### DIFF
--- a/ansible/group_vars/worker
+++ b/ansible/group_vars/worker
@@ -1,0 +1,2 @@
+# See roles/common/defaults/main.yml
+kernel_vm_overcommit_memory: 2


### PR DESCRIPTION
Assign `kernel_vm_overcommit_memory` on the servers in the `worker`
inventory group.  This sets vm.overcommit_memory.

This was left out of commit 3bc3305d, as an oversight.  That commit
attempted to set this parameter to prevent problems with ingestion
processes requesting too much memory, something that is actually more
likely to happen on the `worker` servers.  I had apparently forgotten
that, though both the `worker` and `ingestion_app` inventory groups have
the `ingestion_app` role applied, they are separate groups, and require
separate `group_vars` files.