### PR TITLE
Log Marmotta's NGINX proxy request time

### DIFF
--- a/ansible/roles/marmotta/templates/etc_nginx_sites-available_marmotta.j2
+++ b/ansible/roles/marmotta/templates/etc_nginx_sites-available_marmotta.j2
@@ -20,6 +20,10 @@ server {
         proxy_redirect default;
         proxy_read_timeout 600s;
         proxy_send_timeout 600s;
+        log_format with_reqtime '$remote_addr - $remote_user [$time_local] '
+                                '"$request" $status $body_bytes_sent '
+                                '$request_time';
+        access_log /var/log/nginx/access.log with_reqtime;
     }
 
 }


### PR DESCRIPTION
Update the configuration of the NGINX reverse-proxy for the marmotta
server, having it log request times in the access log.