### PR TITLE
[site proxy] Enable CORS for API redirects

### DIFF
--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -152,11 +152,15 @@ server {
         rewrite ^/about/map /info/map last;
         rewrite ^/about/schema /info/schema last;
         rewrite ^/platform /info/developers/codex last;
-        rewrite ^/api(.*)$ http://{{ api_hostname }}$1 last;
         rewrite ^/lists(.*)$ http://lists.dp.la$1 last;
         {% if sitemap_host is defined %}
         rewrite ^/sitemap.xml$ http://{{ sitemap_host }}/all_item_urls.xml last;
         {% endif %}
+    }
+
+    location ~ ^/api/(.*)$ {
+         add_header 'Access-Control-Allow-Origin' '*';
+         rewrite ^/api/(.*)$ http://{{ api_hostname }}/$1 last;
     }
 
     location ~ ^/donate(/?|/.*)$ {


### PR DESCRIPTION
Complements dpla/platform#37. This is necessary, since our JSON-LD `@context` URIs are referred to using `http://dp.la/api`.