### PR TITLE
Fix variable inclusion, Omeka deployment

### DIFF
--- a/ansible/playbooks/deploy_exhibitions_development.yml
+++ b/ansible/playbooks/deploy_exhibitions_development.yml
@@ -14,5 +14,6 @@
   vars:
     level: development
   vars_files:
-    - "../vars/development.yml"
     - "../roles/omeka/defaults/main.yml"
+    - "../vars/development.yml"
+    - "../roles/omeka/vars/development.yml"

--- a/ansible/playbooks/deploy_exhibitions_production.yml
+++ b/ansible/playbooks/deploy_exhibitions_production.yml
@@ -14,5 +14,6 @@
   vars:
     level: production
   vars_files:
-    - "../vars/production.yml"
     - "../roles/omeka/defaults/main.yml"
+    - "../vars/production.yml"
+    - "../roles/omeka/vars/production.yml"

--- a/ansible/playbooks/deploy_exhibitions_staging.yml
+++ b/ansible/playbooks/deploy_exhibitions_staging.yml
@@ -14,5 +14,6 @@
   vars:
     level: staging
   vars_files:
-    - "../vars/staging.yml"
     - "../roles/omeka/defaults/main.yml"
+    - "../vars/staging.yml"
+    - "../roles/omeka/vars/staging.yml"


### PR DESCRIPTION
In the Omeka (exhibitions) deployment playbook, ensure that role-local
variables get included for the given environment ("level").