### PR TITLE
Add local directory

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,5 +1,2 @@
-staging
-production
-contentqa
-central
+local
 host_vars

--- a/ansible/roles/api/vars/.gitignore
+++ b/ansible/roles/api/vars/.gitignore
@@ -1,4 +1,3 @@
-development.yml
-staging.yml
-production.yml
-contentqa.yml
+*
+!.gitignore
+!*.dist

--- a/ansible/roles/common/vars/.gitignore
+++ b/ansible/roles/common/vars/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!*.dist

--- a/ansible/roles/dbnode/vars/.gitignore
+++ b/ansible/roles/dbnode/vars/.gitignore
@@ -1,3 +1,3 @@
-development.yml
-staging.yml
-production.yml
+*
+!.gitignore
+!*.dist

--- a/ansible/roles/elasticsearch/vars/.gitignore
+++ b/ansible/roles/elasticsearch/vars/.gitignore
@@ -1,3 +1,6 @@
-production.yml
-staging.yml
-development.yml
+*
+!.gitignore
+!main.yml
+!sample.yml
+!vagrant.yml
+!*.dist

--- a/ansible/roles/frontend/vars/.gitignore
+++ b/ansible/roles/frontend/vars/.gitignore
@@ -1,4 +1,3 @@
-development.yml
-staging.yml
-production.yml
-contentqa.yml
+*
+!.gitignore
+!*.dist

--- a/ansible/roles/ingestion_app/vars/.gitignore
+++ b/ansible/roles/ingestion_app/vars/.gitignore
@@ -1,3 +1,2 @@
-development.yml
-staging.yml
-production.yml
+*
+!.gitignore

--- a/ansible/roles/marmotta/vars/.gitignore
+++ b/ansible/roles/marmotta/vars/.gitignore
@@ -1,3 +1,2 @@
-development.yml
-staging.yml
-production.yml
+*
+!.gitignore

--- a/ansible/roles/munin_master/vars/.gitignore
+++ b/ansible/roles/munin_master/vars/.gitignore
@@ -1,3 +1,4 @@
-staging.yml
-contentqa.yml
-production.yml
+*
+!.gitignore
+!example.yml
+!main.yml

--- a/ansible/roles/mysql/vars/.gitignore
+++ b/ansible/roles/mysql/vars/.gitignore
@@ -1,3 +1,2 @@
-development.yml
-staging.yml
-production.yml
+*
+!.gitignore

--- a/ansible/roles/omeka/vars/.gitignore
+++ b/ansible/roles/omeka/vars/.gitignore
@@ -1,3 +1,2 @@
-development.yml
-production.yml
-staging.yml
+*
+!.gitignore

--- a/ansible/roles/postgresql/vars/.gitignore
+++ b/ansible/roles/postgresql/vars/.gitignore
@@ -1,3 +1,3 @@
-development.yml
-staging.yml
-production.yml
+*
+!.gitignore
+!*.dist

--- a/ansible/roles/tomcat_common/vars/.gitignore
+++ b/ansible/roles/tomcat_common/vars/.gitignore
@@ -1,3 +1,2 @@
-development.yml
-staging.yml
-production.yml
+*
+!.gitignore

--- a/ansible/roles/wordpress/vars/.gitignore
+++ b/ansible/roles/wordpress/vars/.gitignore
@@ -1,3 +1,4 @@
-staging.yml
-production.yml
-development.yml
+*
+!.gitignore
+!main.yml
+!*.dist

--- a/ansible/vars/.gitignore
+++ b/ansible/vars/.gitignore
@@ -1,4 +1,4 @@
-development.yml
-staging.yml
-production.yml
-contentqa.yml
+*
+!.gitignore
+!defaults.yml
+!*.dist


### PR DESCRIPTION
Add a `local` directory that will contain ancillary inventories and playbooks that use roles defined here in `automation`, but that should not exist in this repository.

To test this, try `git status` and verify that it doesn't reveal anything new.  You should not see any untracked files that weren't there before.  Note that operations with inventories other than `development` or `ingestion` will require passing `ansible-playbook` an `-i` option with the new location to the inventory file, under `local/inventory`.

This adds a `.gitignore` exclusion for a new `local` directory (which is up to the user to add) and makes various `.gitignore` files more flexible.
