### PR TITLE
Improve Omeka deployments

### DIFF
--- a/ansible/roles/omeka/defaults/main.yml
+++ b/ansible/roles/omeka/defaults/main.yml
@@ -9,3 +9,5 @@ omeka_php_start_servers: 2
 omeka_php_min_spare_servers: 2
 omeka_php_max_spare_servers: 4
 omeka_php_max_requests: 500
+
+skip_site_proxy_cache: false

--- a/ansible/roles/omeka/tasks/deploy.yml
+++ b/ansible/roles/omeka/tasks/deploy.yml
@@ -131,6 +131,7 @@
   command: find /var/cache/nginx -type f -delete
   delegate_to: "{{ item }}"
   with_items: groups.site_proxies
+  when: not skip_site_proxy_cache
   tags:
     - deployment
     - omeka

--- a/ansible/roles/omeka/templates/etc_nginx_sites_available_omeka.j2
+++ b/ansible/roles/omeka/templates/etc_nginx_sites_available_omeka.j2
@@ -8,6 +8,10 @@ server {
     # media file uploads.  Also see the siteproxy configuration.
     client_max_body_size 25m;
 
+    location ~ ^/$ {
+        return 301 http://$host/exhibitions/;
+    }
+
     location /exhibitions {
 
         root /srv/www;


### PR DESCRIPTION
- Allow the `omeka` role to work outside of our normal production
  environment, by adding the skip_site_proxy_cache variable, which makes
the installation independent of the `site_proxy` role.

- Add an NGINX redirect for a standalone exhibitions server, sending
  requests for `/` to `/exhibitions/`.