### PR TITLE
Add missing playbooks for Exhibitions

### DIFF
--- a/ansible/playbooks/exhibitions_development.yml
+++ b/ansible/playbooks/exhibitions_development.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Gather inventory facts in case playbook is run standalone
+  hosts: all
+
+- name: Exhibitions (development)
+  hosts: exhibitions
+  sudo: yes
+  serial: 1
+  tasks:
+    - include: ../roles/omeka/tasks/main.yml
+  handlers:
+    - include: ../roles/omeka/handlers/main.yml
+  vars:
+    level: development
+  vars_files:
+    - "../roles/omeka/defaults/main.yml"
+    - "../vars/development.yml"
+    - "../roles/omeka/vars/development.yml"

--- a/ansible/playbooks/exhibitions_production.yml
+++ b/ansible/playbooks/exhibitions_production.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Gather inventory facts in case playbook is run standalone
+  hosts: all
+
+- name: Exhibitions (production)
+  hosts: exhibitions
+  sudo: yes
+  serial: 1
+  tasks:
+    - include: ../roles/omeka/tasks/main.yml
+  handlers:
+    - include: ../roles/omeka/handlers/main.yml
+  vars:
+    level: production
+  vars_files:
+    - "../roles/omeka/defaults/main.yml"
+    - "../vars/production.yml"
+    - "../roles/omeka/vars/production.yml"

--- a/ansible/playbooks/exhibitions_staging.yml
+++ b/ansible/playbooks/exhibitions_staging.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Gather inventory facts in case playbook is run standalone
+  hosts: all
+
+- name: Exhibitions (staging)
+  hosts: exhibitions
+  sudo: yes
+  serial: 1
+  tasks:
+    - include: ../roles/omeka/tasks/main.yml
+  handlers:
+    - include: ../roles/omeka/handlers/main.yml
+  vars:
+    level: staging
+  vars_files:
+    - "../roles/omeka/defaults/main.yml"
+    - "../vars/staging.yml"
+    - "../roles/omeka/vars/staging.yml"


### PR DESCRIPTION
Add provisioning and configuration playbooks for `omeka' role
(Exhibitions).  There were playbooks for deploying the application, but
not for the other provisioning and configuration tasks (the role's
main.yml).