### PR TITLE
Improve, fix heidrun deployments

### DIFF
--- a/README-ingestion2.md
+++ b/README-ingestion2.md
@@ -55,7 +55,19 @@ The various sites will be online at:
 * http://ingestion2.local.dp.la:8080/solr/#/ (Solr admin interface)
 * http://ldp.local.dp.la/ (Marmotta admin interface)
 
-
 There won't be any data ingested until you run an ingestion.
 
 See the rest of the main [README.md](README.md) file for more information.
+
+## Tips
+
+### Heiðrún deployment
+
+After you do a full deployment, you can deploy just the application files with
+`--extra-vars "fast_deployment=true"`, in order to save time.  This is useful if
+you are developing `heidrun` or `krikri` and are iterating over quick changes to the
+application code, and don't need to provision or configure all of the supporting
+infrastructure.
+
+Example:
+`ansible-playbook -u mb -i ingestion playbooks/deploy_ingestion_app_development.yml --extra-vars="fast_deployment=true"`

--- a/ansible/roles/ingestion_app/defaults/main.yml
+++ b/ansible/roles/ingestion_app/defaults/main.yml
@@ -9,3 +9,8 @@ rails_env: development
 ingestion_secret_key_base: 227577a6f5b650eee5e30d2519872b0163a4b3112449ff4876cf9b5d7bf3edae86935d7dea2b59466ea435617116f9c2dafa6fa19e078e05017693a2a330cebc
 
 unicorn_worker_processes: 2
+
+# fast_deployment skips various tasks and is useful if you've already deployed
+# and are performing iterative changes in development that only affect application
+# code.  It skips things like database migration and updating the bundle.
+fast_deployment: false

--- a/ansible/roles/ingestion_app/files/build_ingestion.sh
+++ b/ansible/roles/ingestion_app/files/build_ingestion.sh
@@ -1,8 +1,27 @@
 #!/bin/bash
 
+# Usage:  build_ingestion.sh [-f] <ruby version> <inventory groups>
+# ... where inventory groups are separated by commas.
+# ... and -f means to go "fast," skipping certain tasks that are unnecessary
+#     if you're making iterative changes to application code.
+# ... and all switches (e.g. -f) must come before other arguments.
+
+fast=0
+while getopts :f opt; do
+    case $opt in
+        f)
+            fast=1
+            ;;
+        \?)
+            >&2 echo "Invalid option -$OPTARG"
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND-1))  # Remove getopts switches from args
+
 use_version=$1
 inventory_groups=`echo $2 | sed 's/,/ /g'`
-
 
 echo $inventory_groups | grep ingestion_app > /dev/null \
     && do_webapp=1 || do_webapp=0
@@ -15,8 +34,10 @@ eval "`rbenv init -`"
 cd /home/dpla/heidrun || exit 1
 rbenv global $use_version
 
-bundle install || exit 1
-rbenv rehash
+if [ $fast == 0 ]; then
+    bundle install || exit 1
+    rbenv rehash
+fi
 
 /usr/bin/rsync -rptolg --checksum --delete --delay-updates \
     --exclude 'log' \
@@ -50,7 +71,10 @@ done
 
 cd /opt/heidrun
 if [ $do_webapp -eq 1 ]; then
-    bundle exec rake db:migrate || exit 1
     bundle exec rake assets:precompile || exit 1
+    if [ $fast -eq 0 ]; then
+        bundle exec rake db:migrate || exit 1
+    fi
 fi
+
 bundle exec rake tmp:clear || exit 1

--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -142,6 +142,13 @@
     dest=/home/dpla/heidrun/config/settings.local.yml
     owner=dpla group=dpla mode=0644
 
+- name: Update configuration for test environment
+  # On overriding settings:  https://github.com/railsconfig/rails_config#common-config-file
+  template: >-
+    src=config_environments_test.local.yml.j2
+    dest=/home/dpla/heidrun/config/environments/test.local.yml
+    owner=dpla group=dpla mode=0644
+
 - name: Update unicorn.rb
   template: >-
       src=unicorn.rb.j2 dest=/home/dpla/heidrun/config/unicorn.rb

--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -11,7 +11,7 @@
   run_once: true
   with_items: groups.solr
   notify: restart tomcat
-  when: not ingestion_use_local_source
+  when: not ingestion_use_local_source and not fast_deployment
 
 - name: Ensure that Solr schema file is current (local)
   # Only makes sense in development VM, and assumes /heidrun is mounted in
@@ -20,7 +20,7 @@
   register: script_result
   changed_when: "'changed' in script_result.stdout"
   notify: restart tomcat
-  when: ingestion_use_local_source
+  when: ingestion_use_local_source and not fast_deployment
 
 - name: Ensure the state of solrconfig.xml (network)
   get_url: >-
@@ -31,7 +31,7 @@
   run_once: true
   with_items: groups.solr
   notify: restart tomcat
-  when: not ingestion_use_local_source
+  when: not ingestion_use_local_source and not fast_deployment
 
 - name: Ensure the state of solrconfig.xml (local)
   # See above
@@ -39,7 +39,7 @@
   register: script_result
   changed_when: "'changed' in script_result.stdout"
   notify: restart tomcat
-  when: ingestion_use_local_source
+  when: ingestion_use_local_source and not fast_deployment
 
 - name: Fix dataDir in solrconfig.xml
   lineinfile: >-
@@ -50,6 +50,7 @@
   run_once: true
   with_items: groups.solr
   notify: restart tomcat
+  when: not fast_deployment
 
 - name: Fix lib in solrconfig.xml for classpath loading
   lineinfile: >-
@@ -60,6 +61,7 @@
   run_once: true
   with_items: groups.solr
   notify: restart tomcat
+  when: not fast_deployment
 
 - meta: flush_handlers
 
@@ -70,8 +72,7 @@
   script: >-
       ../../../files/install_ruby_tools.sh {{ ingestion_rbenv_version }}
   sudo_user: dpla
-  tags:
-    - deployment
+  when: not fast_deployment
 
 # Clear these out prior to copying and symlinking below
 - file: path=/home/dpla/heidrun state=absent
@@ -85,8 +86,6 @@
       version={{ heidrun_branch_or_tag }}
   sudo_user: dpla
   when: not ingestion_use_local_source
-  tags:
-    - deployment
 
 - name: Check out mappings from their repository (not using local source)
   git: >-
@@ -95,8 +94,6 @@
       version={{ heidrun_mappings_branch_or_tag }}
   sudo_user: dpla
   when: not ingestion_use_local_source
-  tags:
-    - deployment
 
 # Symlink to the build directories, to allow local and git builds to coexist neatly
 # 1. For a git deployment ...
@@ -110,8 +107,6 @@
   script: copy_local_app.sh
   sudo_user: dpla
   when: ingestion_use_local_source
-  tags:
-    - deployment
 
 # Symlinking, as above
 # 2. For a local filesystem deployment ...
@@ -127,14 +122,10 @@
     line="gem 'krikri', path: '/home/dpla/krikri'"
   sudo_user: dpla
   when: ingestion_use_local_source
-  tags:
-    - deployment
 
 - name: Remove Gemfile.lock
   # In case of a change in local vs. network deployment
   file: path=/home/dpla/heidrun/Gemfile.lock state=absent
-  tags:
-    - deployment
 
 - name: Update ingestion app configuration files
   template: >-
@@ -143,8 +134,6 @@
   with_items:
     - database.yml
     - secrets.yml
-  tags:
-    - deployment
 
 - name: Update Redis settings in ingestion app
   # See https://github.com/resque/resque#configuration
@@ -152,8 +141,6 @@
     src=config_settings.local.yml.j2
     dest=/home/dpla/heidrun/config/settings.local.yml
     owner=dpla group=dpla mode=0644
-  tags:
-    - deployment
 
 - name: Update unicorn.rb
   template: >-
@@ -161,13 +148,9 @@
       owner=dpla group=dpla mode=0644
   when: >-
     'ingestion_app' in hostvars[inventory_hostname]['group_names']
-  tags:
-    - deployment
 
 - name: Ensure existence of live app directory
   file: path=/opt/heidrun state=directory owner=dpla group=dpla mode=0755
-  tags:
-    - deployment
 
 - name: Stop Unicorn (gracefully)
   # Unicorn is stopped completely, and later restarted, because we assume that
@@ -178,27 +161,19 @@
   service: name=unicorn_heidrun state=stopped
   when: >-
     'ingestion_app' in hostvars[inventory_hostname]['group_names']
-  tags:
-    - deployment
 
 - name: Build web application (and copy to live directory)
   script: >-
-    ../files/build_ingestion.sh {{ ingestion_rbenv_version }}
+    ../files/build_ingestion.sh "{{ '-f' if fast_deployment else '' }}" {{ ingestion_rbenv_version }}
     {{ hostvars[inventory_hostname]['group_names'] | join(',') }}
   sudo_user: dpla
-  tags:
-    - deployment
 
 - name: Start Unicorn
   service: name=unicorn_heidrun state=started
   when: >-
     'ingestion_app' in hostvars[inventory_hostname]['group_names']
-  tags:
-    - deployment
 
 - name: Restart worker process manager
   service: name=god_heidrun state=restarted
   when: >-
     'worker' in hostvars[inventory_hostname]['group_names']
-
-

--- a/ansible/roles/ingestion_app/templates/config_environments_test.local.yml.j2
+++ b/ansible/roles/ingestion_app/templates/config_environments_test.local.yml.j2
@@ -1,0 +1,10 @@
+---
+
+marmotta:
+  base: 'http://localhost:8983/marmotta'
+  ldp: 'http://localhost:8983/marmotta/ldp'
+  record_container: 'http://localhost:8983/marmotta/ldp/original_record'
+  item_container: 'http://localhost:8983/marmotta/ldp/items'
+
+solr:
+  url: "http://localhost:8983/solr"

--- a/ansible/roles/ingestion_app/templates/database.yml.j2
+++ b/ansible/roles/ingestion_app/templates/database.yml.j2
@@ -6,10 +6,10 @@ test:
   adapter: postgresql
   encoding: unicode
   host: {{ db_host }}
-  database: ingestion_test
-  username: {{ postgresql_user['name'] }}
-  password: {{ postgresql_user['password'] }}
-  port: 5432
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+  database: db/test.sqlite3
 
 development:
   adapter: postgresql


### PR DESCRIPTION
These changes facilitate development on `heidrun` and `krikri` using the VMs.

* A new "fast deployment" variable has been added, that speeds up application code-only deployments.
* Configuration and database problems have been fixed, allowing spec tests to be run on the dev2 VM.

Now that I can run `bundle exec rake ci` on `dev2`, I occasionally encounter the following error:
```/home/dpla/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/net-http-persistent-2.9.4/lib/net/http/persistent.rb:641:in `rescue in connection_for': connection refused: localhost:8983 (Net::HTTP::Persistent::Error)```
This happened once or twice and I haven't been able to reproduce it.  I mention it here in case it speaks of some configuration change that could be made in this project.
