### PR TITLE
Add task to ensure common Munin plugins are enabled

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -78,6 +78,20 @@
   tags:
     - munin
 
+- name: Ensure that certain Munin plugins are enabled
+  # Munin enables a lot of plugins by default, but these are just ones
+  # that we want to ensure are running regardless of the defaults.
+  file: >-
+      src=/usr/share/munin/plugins/{{ item }}
+      dest=/etc/munin/plugins/{{ item }}
+      state=link owner=root group=root
+  with_items:
+    - netstat
+    - tcp
+  notify: restart munin node
+  tags:
+    - munin
+
 - name: Ensure state of munin node configuration file
   template: src=munin-node.conf.j2 dest=/etc/munin/munin-node.conf owner=root group=root mode=0644
   notify: restart munin node


### PR DESCRIPTION
Add a task to ensure that specific Munin plugins will always be
installed.

Two network plugins have been explicitly enabled, which are enabled by
default on Ubuntu 14.04, but not 12.04.