### PR TITLE
Minor Fixes for a From-scratch Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ If you want to work with our new Ingestion2 system, please see
   * `ansible/roles/postgresql/vars/development.yml.dist`
   * `ansible/roles/frontend/vars/development.yml.dist`
     * Optional.  For the frontend app, as above.  See `Vagrantfile`.
-  * `ansible/roles/elasticsearch/vars/development.yml.dist`
 * Optionally, copy and update any other `ansible/roles/*/development.yml.dist`
   files in a similar fashion.  There are defaults that will take effect if you don't
   make any changes.

--- a/Vagrantfile.dist
+++ b/Vagrantfile.dist
@@ -19,8 +19,11 @@ dbnodes = {
 }
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    # Use the default insecure_private_key so ansible doesn't need to 
+    # know about all the generated ones.
+    config.ssh.insert_key = false
 
-	# All boxes are hashicorp/precise64, which is Ubuntu 12.04 LTS
+    # All boxes are hashicorp/precise64, which is Ubuntu 12.04 LTS
 
     # BigCouch and ElasticSearch servers.
     # Necessary in all cases.

--- a/Vagrantfile.ingestion2
+++ b/Vagrantfile.ingestion2
@@ -12,6 +12,9 @@
 VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Use the default insecure_private_key so ansible doesn't need to
+  # know about all the generated ones.
+  config.ssh.insert_key = false
 
   # Frontend, web, ElasticSearch
   config.vm.define :dev1 do |dev1|

--- a/ansible/playbooks/elasticsearch.yml
+++ b/ansible/playbooks/elasticsearch.yml
@@ -41,6 +41,7 @@
         aws_region: "{{ aws_region }}"
         state: absent
     - name: Wait for connections to drain
+      when: level == 'production' or level == 'staging'
       wait_for: >-
           host="{{ inventory_hostname }}" port="9200" state=drained timeout=60
   post_tasks:


### PR DESCRIPTION
This fixes a handful of minor issues I ran into when building the automation project from scratch today.

  - Removes a duplicate bullet point from `README.md`
  - Forces Vagrant to use the default `insecure_private_key`. Some versions overwrite that key on new machines by default, breaking Ansible's SSH initial login as the `vagrant` user.
  - Fixes an error with the elasticsearch jobs in `development`.