### PR TITLE
Fix the config/solr.yml file deployed with heidrun

### DIFF
--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -142,6 +142,12 @@
     dest=/home/dpla/heidrun/config/settings.local.yml
     owner=dpla group=dpla mode=0644
 
+- name: Update solr.yml file in ingestion app
+  template: >-
+    src=config_solr.yml.j2
+    dest=/home/dpla/heidrun/config/solr.yml
+    owner=dpla group=dpla mode=0644
+
 - name: Update configuration for test environment
   # On overriding settings:  https://github.com/railsconfig/rails_config#common-config-file
   template: >-

--- a/ansible/roles/ingestion_app/templates/config_solr.yml.j2
+++ b/ansible/roles/ingestion_app/templates/config_solr.yml.j2
@@ -1,0 +1,21 @@
+# = jetty_path key
+# each environment can have a jetty_path with absolute or relative
+# (to app root) path to a jetty/solr install. This is used
+# by the rake tasks that start up solr automatically for testing
+# and by rake solr:marc:index.  
+#
+# jetty_path is not used by a running Blacklight application
+# at all. In general you do NOT need to deploy solr in Jetty, you can deploy it
+# however you want.  
+# jetty_path is only required for rake tasks that need to know
+# how to start up solr, generally for automated testing. 
+
+{# for now, we just assume that there is one Solr server #}
+{% set solr_host = groups['solr'][0] %}
+
+development:
+  url: <%= ENV['SOLR_URL'] || "http://{{ solr_host }}:8080/solr" %>
+test: &test
+  url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8888}/solr" %>
+production:
+  url: <%= ENV['SOLR_URL'] || "http://{{ solr_host }}:8080/solr" %>


### PR DESCRIPTION
At deployment, update the config/solr.yml file in `heidrun` with
appropriate values for our environment.

The development and production values were previously getting set
with "http://127.0.0.1:8983/solr"