### PR TITLE
Add HOME environment var to god config

### DIFF
--- a/ansible/roles/ingestion_app/templates/heidrun.god.j2
+++ b/ansible/roles/ingestion_app/templates/heidrun.god.j2
@@ -14,7 +14,8 @@
     w.env      = {
       'PATH' => '/home/dpla/.rbenv/shims:/home/dpla/.rbenv/bin:/usr/local/bin:/usr/bin:/bin',
       'QUEUE' => '{{ queue.name }}',
-      'RAILS_ENV' => '{{ rails_env }}'
+      'RAILS_ENV' => '{{ rails_env }}',
+      'HOME' => '/home/dpla'
     }
     w.start    = "bundle exec rake environment resque:work"
     w.log      = '/opt/heidrun/log/worker.log'


### PR DESCRIPTION
Have god start resque workers with the $HOME environment variable
correctly set.

I noticed that my workers in my development VMs were not able to start
without this being set.  There were errors in
/opt/heidrun/log/worker.log indicating:
  ArgumentError: couldn't find HOME environment -- expanding `~'