### PR TITLE
Improve Solr index and configuration operations

### DIFF
--- a/README-ingestion2.md
+++ b/README-ingestion2.md
@@ -72,6 +72,22 @@ infrastructure.
 Example:
 `ansible-playbook -u mb -i ingestion playbooks/deploy_ingestion_app_development.yml --extra-vars="fast_deployment=true"`
 
+### Heiðrún deployments with Solr changes
+
+Sometimes a Heiðrún deployment will carry along with it some Solr schema or
+configuration changes.  When this happens, the Solr search index that's used
+for QA will have to be deleted and re-created.  An Ansible task will be
+triggered to delete the index, but you will have to re-index your repository
+records yourself.  This is not automated yet, and will have to be done in the
+Rails console, per this example:
+https://digitalpubliclibraryofamerica.atlassian.net/wiki/display/TECH/Queue+an+Indexing
+
+It seems that a first-time indexing run after the schema is changed, the
+index is deleted, and the Solr core is restarted requires a reload of the
+core again for the added documents to show up.  You can reload the Solr
+core at http://ingestion2.local.dp.la:8080/solr/#/~cores/collection1
+
+
 ### When to use this and other DPLA project VMs
 
 There are Vagrantfiles in the `krikri` and `heidrun` projects, too.  Why should

--- a/ansible/roles/ingestion_app/handlers/main.yml
+++ b/ansible/roles/ingestion_app/handlers/main.yml
@@ -11,3 +11,29 @@
   delegate_to: "{{ item }}"
   with_items: groups.solr
   run_once: true
+
+- name: clear solr index
+  uri:
+    method: POST
+    url: "http://{{ groups['solr'][0] }}:8080/solr/update"
+    HEADER_Content-type: "text/xml; charset=utf-8"
+    body_format: raw
+    body: "<delete><query>*:*</query></delete>"
+  delegate_to: 127.0.0.1
+  sudo: no
+
+- name: commit solr index
+  uri:
+    method: POST
+    url: "http://{{ groups['solr'][0] }}:8080/solr/update"
+    HEADER_Content-type: "text/xml; charset=utf-8"
+    body_format: raw
+    body: "<commit/>"
+  delegate_to: 127.0.0.1
+  sudo: no
+
+- name: reload solr core
+  uri:
+    url: "http://{{ groups['solr'][0] }}:8080/solr/admin/cores?action=RELOAD&core=collection1"
+  delegate_to: 127.0.0.1
+  sudo: no

--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -10,7 +10,10 @@
   delegate_to: "{{ item }}"
   run_once: true
   with_items: groups.solr
-  notify: restart tomcat
+  notify:
+    - clear solr index
+    - commit solr index
+    - reload solr core
   when: not ingestion_use_local_source and not fast_deployment
 
 - name: Ensure that Solr schema file is current (local)
@@ -19,7 +22,10 @@
   script: copy_local_solrconf.sh schema.xml
   register: script_result
   changed_when: "'changed' in script_result.stdout"
-  notify: restart tomcat
+  notify:
+    - clear solr index
+    - commit solr index
+    - reload solr core
   when: ingestion_use_local_source and not fast_deployment
 
 - name: Ensure the state of solrconfig.xml (network)
@@ -30,7 +36,7 @@
   delegate_to: "{{ item }}"
   run_once: true
   with_items: groups.solr
-  notify: restart tomcat
+  notify: reload solr core
   when: not ingestion_use_local_source and not fast_deployment
 
 - name: Ensure the state of solrconfig.xml (local)
@@ -38,7 +44,7 @@
   script: copy_local_solrconf.sh solrconfig.xml
   register: script_result
   changed_when: "'changed' in script_result.stdout"
-  notify: restart tomcat
+  notify: reload solr core
   when: ingestion_use_local_source and not fast_deployment
 
 - name: Fix dataDir in solrconfig.xml
@@ -49,7 +55,7 @@
   delegate_to: "{{ item }}"
   run_once: true
   with_items: groups.solr
-  notify: restart tomcat
+  notify: reload solr core
   when: not fast_deployment
 
 - name: Fix lib in solrconfig.xml for classpath loading
@@ -60,7 +66,7 @@
   delegate_to: "{{ item }}"
   run_once: true
   with_items: groups.solr
-  notify: restart tomcat
+  notify: reload solr core
   when: not fast_deployment
 
 - meta: flush_handlers


### PR DESCRIPTION
- Delete Solr index when there is a schema change.
- Reload the Solr core instead of restarting Tomcat.

There is no standalone playbook for clearing the Solr index, which would
be nice, but which would take longer to put together than I can afford
right now, because I'd have to spend more effort to avoid duplicating
code in that case.

After clearing the index, you have to run a new indexing operation,
which is out of the scope of the `automation` project.  Just note that
that has to happen.  It seems that a first-time indexing run after the
schema is changed, the index is deleted, and the Solr core is restarted
requires a reload of the core again for the added documents to show up.
I don't have an explanation for that, and I'm not sure whether it has to
do with deleting the index, or something that should be done when the
records are re-indexed.