### PR TITLE
Set PostgreSQL random_page_cost

### DIFF
--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -5,5 +5,8 @@ pg_max_connections: 50
 pg_shared_buffers: 24MB
 pg_effective_cache_size: 128MB
 pg_work_mem: 1MB
+# The default random_page_cost of 4.0 assumes you're using disks.
+# Decrease it if you're using SSD drives.  1.5 might be a good value.
+pg_random_page_cost: 4.0
 pg_backup_keep_days: 7
 backups_basedir: /backups

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -240,8 +240,8 @@ checkpoint_completion_target = 0.9	# checkpoint target duration, 0.0 - 1.0
 
 # - Planner Cost Constants -
 
-#seq_page_cost = 1.0			# measured on an arbitrary scale
-#random_page_cost = 4.0			# same scale as above
+seq_page_cost = 1.0			# measured on an arbitrary scale
+random_page_cost = {{ pg_random_page_cost }}  # same scale as above
 #cpu_tuple_cost = 0.01			# same scale as above
 #cpu_index_tuple_cost = 0.005	# same scale as above
 #cpu_operator_cost = 0.0025		# same scale as above


### PR DESCRIPTION
Use a parameter to set random_page_cost.  This is a minor change that
won't result in a major impact, but it's easy to make.  A lower
random_page_cost is more appropriate for SSD drives or Amazon EBS
volumes.