### PR TITLE
Disable Marmotta reasoner

### DIFF
--- a/ansible/roles/marmotta/templates/system-config.properties.j2
+++ b/ansible/roles/marmotta/templates/system-config.properties.j2
@@ -178,3 +178,4 @@ user.admin.roles = manager
 user.admin.roles = user
 marmotta.home = {{ marmotta_home }}
 ldcache.enabled = false
+reasoning.enabled = false


### PR DESCRIPTION
Per discussion on 2015-06-25, we are disabling the reasoner module for Marmotta,
which will allow us to partition Marmotta's database tables more effectively.

(cc @markbreedlove - please add any salient details)