### PR TITLE
Change bundle install to bundle update

### DIFF
--- a/ansible/roles/api/files/build_api.sh
+++ b/ansible/roles/api/files/build_api.sh
@@ -14,7 +14,7 @@ rbenv shell $USE_VERSION
 
 echo "installing bundle ..." >> $LOGFILE
 
-bundle install
+bundle update
 rbenv rehash
 
 echo "rsync from home to /srv/www/api ..." >> $LOGFILE

--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -18,7 +18,7 @@ rbenv shell $USE_VERSION
 
 echo "installing bundle ..." >> $LOGFILE
 
-bundle install
+bundle update
 bundle update dpla_frontend_assets
 rbenv rehash
 

--- a/ansible/roles/ingestion_app/files/build_ingestion.sh
+++ b/ansible/roles/ingestion_app/files/build_ingestion.sh
@@ -44,7 +44,7 @@ rbenv global $use_version
 echo "installing bundle ..." >> $LOGFILE
 
 if [ $fast == 0 ]; then
-    bundle install || exit 1
+    bundle update || exit 1
     rbenv rehash
 fi
 


### PR DESCRIPTION
In scripts that update Ruby gem bundles, use `bundle update` instead of
`install`, in order to upgrade versions of gems.

See http://bundler.io/v1.3/man/bundle-update.1.html