### PR TITLE
Set max. request body size, Marmotta NGINX proxy

### DIFF
--- a/ansible/roles/marmotta/tasks/main.yml
+++ b/ansible/roles/marmotta/tasks/main.yml
@@ -38,6 +38,8 @@
       dest="/etc/nginx/sites-available/marmotta"
       owner=root group=root mode=0644
   notify: restart nginx
+  tags:
+    - nginx
 
 - name: Make sure nginx logs get rotated
   template: >-

--- a/ansible/roles/marmotta/templates/etc_nginx_sites-available_marmotta.j2
+++ b/ansible/roles/marmotta/templates/etc_nginx_sites-available_marmotta.j2
@@ -9,6 +9,16 @@ server {
     server_name {{ inventory_hostname }};
 {% endif %}
 
+    # Maximum request body size.  (Controls maximum size of
+    # a PUT or POST to Marmotta.)
+    # It's not clear whether this is sufficient, or if there's something
+    # that should also be set in Tomcat, e.g. maxPostSize (which, if you
+    # take it literally, does not apply to PUT) or
+    # //servlet/multipart-config/max-request-size inside of a web.xml file.
+    # The web.xml contained inside of marmotta.war does not have a
+    # //servlet element that would pertain.
+    client_max_body_size 8m;
+
     location / {
         # Proxy everything to Marmotta.
         # E.g. http://ldp.somedomain.org/ --> http://thishost:8080/


### PR DESCRIPTION
Set the maximum request body size, client_max_body_size, in the virtual host of the NGINX reverse proxy in front of Marmotta.  The NGINX default of 1MB has been preventing larger records from being PUT.

See the comment in the template about other Tomcat parameters, but this is at least a step.  After the change, I am able to harvest a record that used to be refused due to its large size.  I've set the maximum request body size to 8 MB, which I think is pretty generous.  I haven't been able to determine Tomcat's default maximum request body size for a PUT request.

