### PR TITLE
Add geocoder role

### DIFF
--- a/ansible/group_vars/geocoder
+++ b/ansible/group_vars/geocoder
@@ -1,0 +1,2 @@
+# See roles/common/defaults/main.yml
+kernel_vm_overcommit_memory: 2

--- a/ansible/playbooks/geocoder.yml
+++ b/ansible/playbooks/geocoder.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Gather inventory facts in case playbook is run standalone
+  hosts: all
+
+- name: Geocoder (twofishes)
+  hosts: geocoder
+  sudo: yes
+  roles:
+    - geocoder
+  vars_files:
+    - ["../vars/{{ level }}.yml", "../vars/defaults.yml"]
+

--- a/ansible/playbooks/geocoder_production.yml
+++ b/ansible/playbooks/geocoder_production.yml
@@ -1,0 +1,3 @@
+---
+
+- include: geocoder.yml level=production

--- a/ansible/roles/geocoder/defaults/main.yml
+++ b/ansible/roles/geocoder/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+twofishes_version: "0.84.9"
+twofishes_jar_name: "server-assembly-{{ twofishes_version }}.jar"
+twofishes_index_base: "2015-03-05"
+twofishes_index_archive: "{{ twofishes_index_base }}.zip"

--- a/ansible/roles/geocoder/files/etc_logrotate.d_twofishes
+++ b/ansible/roles/geocoder/files/etc_logrotate.d_twofishes
@@ -1,0 +1,9 @@
+/opt/twofishes/log/twofishes.log {
+    rotate 14
+    daily
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/ansible/roles/geocoder/handlers/main.yml
+++ b/ansible/roles/geocoder/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: restart twofishes
+  service: name=twofishes state=restarted

--- a/ansible/roles/geocoder/tasks/main.yml
+++ b/ansible/roles/geocoder/tasks/main.yml
@@ -1,0 +1,103 @@
+---
+
+- name: Ensure existence of necessary packages
+  apt: >-
+      pkg="{{ item }}" state=present
+  with_items:
+    - zip
+    - default-jre
+  tags:
+    - packages
+
+- name: Ensure existence of the "geocoder" account
+  user: >-
+      name=geocoder comment="Twofishes privsep user"
+      home=/home/geocoder shell=/bin/bash state=present
+  tags:
+    - users
+
+- name: Ensure state of twofishes directory
+  file: >-
+    path=/opt/twofishes state=directory
+    owner=root group=root mode=0755
+
+- name: Check the twofishes index directory
+  file: >-
+    path=/opt/twofishes/index state=directory
+    owner=root group=root mode=0755
+
+- name: Check the twofishes log directory
+  file: >-
+    path=/opt/twofishes/log state=directory
+    owner=geocoder group=geocoder mode=0755
+
+- name: Check whether twofishes is installed
+  stat: >-
+    path="/opt/twofishes/{{ twofishes_jar_name }}"
+  register: twofishes_jar
+
+# TODO:  With Ansible 2.0, we might want to use the `find` module to
+# search for a directory-name pattern, but this may still be more direct.
+- name: Check whether twofishes index exists
+  shell: "test -d /opt/twofishes/index/{{ twofishes_index_base }}*"
+  register: index_test_result
+  ignore_errors: true
+
+- name: "Download twofishes, if necessary"
+  get_url: >-
+    url="http://twofishes.net/binaries/{{ twofishes_jar_name }}"
+    dest="/opt/twofishes/{{ twofishes_jar_name }}"
+  when: not twofishes_jar.stat.exists
+  notify: restart twofishes
+
+# TODO:  With Ansible 2.0, we should be able to use `unarchive` for both the
+# download and extraction, below.
+
+- name: "Download index, if necessary"
+  when: index_test_result.rc == 1
+  get_url: >-
+    url="http://twofishes.net/indexes/revgeo/{{ twofishes_index_archive }}"
+    dest="/opt/twofishes/index"
+
+- name: "Extract index, if necessary"
+  when: index_test_result.rc == 1
+  unarchive: >-
+    copy=false
+    src="/opt/twofishes/index/{{ twofishes_index_archive }}"
+    dest="/opt/twofishes/index"
+
+- name: Remove index archive file
+  file: >-
+    path="/opt/twofishes/index/{{ twofishes_index_archive }}" state=absent
+
+# This may seem like extra work, but the name of the extracted index directory
+# is different than the base name of the archive file, and this avoids having
+# too many Ansible variables to manage.
+- name: Find the name of the index directory for the init script template
+  shell: >-
+    find /opt/twofishes/index -type d -name '{{ twofishes_index_base }}*' -prune
+  register: index_dir_name_result
+
+- name: Make sure that the twofishes init script is up-to-date
+  template: >-
+    src=etc_init.d_twofishes.j2 dest=/etc/init.d/twofishes
+    owner=root group=root mode=0755
+  notify: restart twofishes
+
+- name: Clear init script runlevels in case of a change
+  command: update-rc.d -f twofishes remove
+  tags:
+    - initscripts
+
+- name: Ensure init script run levels
+  command: update-rc.d twofishes defaults
+  tags:
+    - initscripts
+
+- name: Ensure state of logrotate configuration
+  copy: >-
+    src=etc_logrotate.d_twofishes dest=/etc/logrotate.d/twofishes
+    owner=root group=root mode=0644
+  tags:
+    - logrotate
+

--- a/ansible/roles/geocoder/templates/etc_init.d_twofishes.j2
+++ b/ansible/roles/geocoder/templates/etc_init.d_twofishes.j2
@@ -1,0 +1,67 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides: twofishes
+# Required-Start: $all
+# Required-Stop: $network $local_fs $syslog
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: Start/stop Twofishes
+# Description: Start/stop Twofishes
+### END INIT INFO
+
+set -u
+set -e
+
+. /lib/lsb/init-functions
+
+
+JAR={{ twofishes_jar_name }}
+INDEX_DIR={{ index_dir_name_result.stdout_lines.0 }}
+JAVA_OPTS=""
+CMD_OPTS="$JAVA_OPTS -jar /opt/twofishes/$JAR --hfile_basepath $INDEX_DIR"
+PIDFILE=/opt/twofishes/twofishes.pid
+
+usage() {
+    echo >&2 "Usage: $0 <start|stop|restart|reload|status|usage>"
+}
+
+start() {
+    log_daemon_msg "Starting twofishes" "twofishes"
+    start-stop-daemon --start --quiet --oknodo -c geocoder \
+        --pidfile $PIDFILE -m -b \
+        --startas /bin/bash \
+        -- -c "exec /usr/bin/java $CMD_OPTS >> /opt/twofishes/log/twofishes.log 2>&1"
+    # Because it's backgrounded with -b, this will probably always return
+    # a success status.  See start-stop-daemon (8).
+    log_end_msg $?
+}
+
+stop() {
+    log_daemon_msg "Stopping twofishes" "twofishes"
+    start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE -R 4
+    log_end_msg $?
+    rm -f $PIDFILE
+}
+
+case $1 in
+start)
+    start
+    ;;
+stop)
+    stop
+    ;;
+restart|reload)
+    stop && start
+    ;;
+status)
+    status_of_proc -p $PIDFILE /usr/bin/java twofishes && exit 0 || exit $?
+    ;;
+usage)
+    usage
+    exit 0
+    ;;
+*)
+    usage
+    exit 1
+    ;;
+esac

--- a/ansible/roles/geocoder/vars/.gitignore
+++ b/ansible/roles/geocoder/vars/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!*.dist

--- a/ansible/roles/munin_master/vars/main.yml
+++ b/ansible/roles/munin_master/vars/main.yml
@@ -28,3 +28,4 @@ munin_groups:
         Marmotta: marmotta_prod
         Solr: solr_prod
         Worker: worker_prod
+        Geocoder: geocoder_prod


### PR DESCRIPTION
Add geocoder role, which runs the Twofishes service for geocoding spatial data during ingestion enrichments.

Provisions are only made for a production server.  I'm hoping that this will work out.  Fitting it into one of the development VMs is either not practical, or will require extra work to deal with Twofishes's memory needs.
