### PR TITLE
Bump PHP upload_max_filesize/post_max_size to 50 MB (fixes #7851)

### DIFF
--- a/ansible/roles/common_php/templates/php.ini.j2
+++ b/ansible/roles/common_php/templates/php.ini.j2
@@ -53,7 +53,7 @@ register_globals = Off
 register_long_arrays = Off
 register_argc_argv = Off
 auto_globals_jit = On
-post_max_size = 8M
+post_max_size = 50M
 magic_quotes_gpc = Off
 magic_quotes_runtime = Off
 magic_quotes_sybase = Off
@@ -78,7 +78,7 @@ cgi.fix_pathinfo=0
 
 file_uploads = On
 ;upload_tmp_dir =
-upload_max_filesize = 25M
+upload_max_filesize = 50M
 max_file_uploads = 20
 
 allow_url_fopen = On

--- a/ansible/roles/omeka/templates/application_config_config.ini.j2
+++ b/ansible/roles/omeka/templates/application_config_config.ini.j2
@@ -246,7 +246,7 @@ mail.transport.type = "Sendmail"
 ; configuration will not exceed the maximum beyond what is set in the 
 ; 'post_max_size' or 'upload_max_filesize' core php.ini directives.
 ;
-upload.maxFileSize = "25M"
+upload.maxFileSize = "50M"
 
 
 ;;;;;;;;

--- a/ansible/roles/omeka/templates/etc_nginx_sites_available_omeka.j2
+++ b/ansible/roles/omeka/templates/etc_nginx_sites_available_omeka.j2
@@ -6,7 +6,7 @@ server {
 
     # This large maximum request body size is assumed to be necessary for
     # media file uploads.  Also see the siteproxy configuration.
-    client_max_body_size 25m;
+    client_max_body_size 50m;
 
     location ~ ^/$ {
         return 301 http://$host/exhibitions/;

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -197,7 +197,7 @@ server {
         # For client_max_body_size, see the Wordpress role's NGINX virtual host
         # configuration.
         # (ansible/roles/wordpress/templates/etc_nginx_sites_available_wordpress.j2)
-        client_max_body_size 8m;
+        client_max_body_size 50m;
 
         # misc rewrites in the top level dir
         #
@@ -272,7 +272,7 @@ server {
         # For client_max_body_size, see the Omeka role's NGINX virtual host
         # configuration.
         # (ansible/roles/omeka/templates/etc_nginx_sites_available_omeka.j2)
-        client_max_body_size 25M;
+        client_max_body_size 50M;
 
         # See above, in /info.
         error_page 502 503 504 =503 /503.html;

--- a/ansible/roles/wordpress/templates/etc_nginx_sites_available_wordpress.j2
+++ b/ansible/roles/wordpress/templates/etc_nginx_sites_available_wordpress.j2
@@ -10,7 +10,7 @@ server {
     # Maximum client request body size, which affects uploads.
     # Also see the same setting as defined upstream in the proxy server's
     # configuration.
-    client_max_body_size 8m;
+    client_max_body_size 50m;
 
     access_log /var/log/nginx/wordpress-access.log;
     error_log /var/log/nginx/wordpress-error.log;

--- a/ansible/roles/wordpress/templates/etc_php5_fpm_pool.d_wp.conf.j2
+++ b/ansible/roles/wordpress/templates/etc_php5_fpm_pool.d_wp.conf.j2
@@ -21,4 +21,4 @@ slowlog = /var/log/php-fpm/wp-slow.log
 catch_workers_output = no
 php_admin_value[error_log] = /var/log/wp-error.log
 php_admin_flag[log_errors] = on
-php_admin_value[upload_max_filesize] = 8M
+php_admin_value[upload_max_filesize] = 50M


### PR DESCRIPTION
Increases the maximum upload size for Omeka and WordPress both within the Nginx virtual hosts used by the application and those used by the site proxy nodes. Fixes the `413 Request Entity Too Large` errors. 

Fixes [#7851](https://issues.dp.la/issues/7851). 