### PR TITLE
Rate-limit the bookshelf section of the frontend application

### DIFF
--- a/ansible/roles/common_web/defaults/main.yml
+++ b/ansible/roles/common_web/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+nginx_log_level: notice

--- a/ansible/roles/common_web/templates/etc_nginx_nginx.conf.j2
+++ b/ansible/roles/common_web/templates/etc_nginx_nginx.conf.j2
@@ -34,7 +34,7 @@ http {
 	##
 
 	access_log /var/log/nginx/access.log;
-	error_log /var/log/nginx/error.log;
+	error_log /var/log/nginx/error.log {{ nginx_log_level }};
 
 	##
 	# Gzip Settings

--- a/ansible/roles/site_proxy/defaults/main.yml
+++ b/ansible/roles/site_proxy/defaults/main.yml
@@ -27,7 +27,7 @@ nginx_bookshelf_max_conn: 2
 # Default maximum request rate, where rate-limiting is performed
 nginx_default_req_rate: 10r/s
 # Maximum request rates for specific areas of the site:
-nginx_bookshelf_req_rate: 2r/s
+nginx_bookshelf_req_rate: 1r/s
 
 # Default number of requests that are delayed for serving if a client's
 # requests per second goes over its threshold.

--- a/ansible/roles/site_proxy/defaults/main.yml
+++ b/ansible/roles/site_proxy/defaults/main.yml
@@ -14,11 +14,29 @@ nginx_real_ip_from_addrs:
 # http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone
 nginx_conn_zone_size: 10m
 nginx_req_zone_size: 10m
+# Zones for specific areas of the site:
+nginx_bookshelf_conn_zone_size: 10m
+nginx_bookshelf_req_zone_size: 10m
 
-# Default requests per second, where rate-limiting is performed
-nginx_default_req_sec: 10
+# Default maximum connections per address, where connection-limiting is
+# performed
+nginx_default_max_conn: 10
+# Maximum connections per address for specific areas of the site:
+nginx_bookshelf_max_conn: 2
+
+# Default maximum request rate, where rate-limiting is performed
+nginx_default_req_rate: 10r/s
+# Maximum request rates for specific areas of the site:
+nginx_bookshelf_req_rate: 2r/s
 
 # Default number of requests that are delayed for serving if a client's
 # requests per second goes over its threshold.
 # See http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req
 nginx_default_req_burst_size: 20
+
+# Level at which connection-limiting events will be logged
+nginx_limit_conn_log_level: notice
+# Level at which rate-limiting events will be logged.  Note that when requests
+# are simply delayed (per the rate and burst parameters), they will be logged at
+# one level lower.
+nginx_limit_req_log_level: notice

--- a/ansible/roles/site_proxy/defaults/main.yml
+++ b/ansible/roles/site_proxy/defaults/main.yml
@@ -6,3 +6,19 @@ siteproxy_503_message: >-
 
 nginx_real_ip_from_addrs:
     - 192.168.50.0/24
+
+# Sizes of NGINX shared memory zones for storing states of requests and
+# connections, for rate limiting.
+# See:
+# http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone
+# http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone
+nginx_conn_zone_size: 10m
+nginx_req_zone_size: 10m
+
+# Default requests per second, where rate-limiting is performed
+nginx_default_req_sec: 10
+
+# Default number of requests that are delayed for serving if a client's
+# requests per second goes over its threshold.
+# See http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req
+nginx_default_req_burst_size: 20

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -60,6 +60,7 @@ map $http_content_type $do_not_cache {
     "application/json"      1;  
 }
 
+# Addresses that are not subject to rate or connection limiting
 geo $whitelisted {
     default 1;
     127.0.0.1/32 0;
@@ -68,14 +69,17 @@ geo $whitelisted {
     23.23.40.181/32 0;
 }
 
-map $whitelisted $limit {
+map $whitelisted $addr_to_limit {
     1 $binary_remote_addr;
     0 "";
 }
 
-# Zone Size is 10m, each session is 32 bytes, which is 327680 total session capacity.
-limit_conn_zone $limit zone=pageconnzone:10m;
-limit_req_zone  $limit zone=pagereqzone:10m rate=10r/s;
+# Default connection and request zones.
+# See above for definition of $addr_to_limit.
+# For memory usage explanation, see:
+#  http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone
+limit_conn_zone $addr_to_limit zone=defaultconnzone:{{ nginx_conn_zone_size }};
+limit_req_zone  $addr_to_limit zone=defaultreqzone:{{ nginx_req_zone_size }} rate={{ nginx_default_req_sec }}r/s;
 
 {% if ingestion2 is not defined %}
 
@@ -134,9 +138,9 @@ server {
         proxy_ignore_headers Cache-Control Set-Cookie;
 
         # Up to 10 simultaneous page requests per IP 
-        limit_conn pageconnzone 10;
+        limit_conn defaultconnzone 10;
         # Up to 20 requests / sec for pages.
-        limit_req zone=pagereqzone burst=20;
+        limit_req zone=defaultreqzone burst={{ nginx_default_req_burst_size }};
     
         proxy_pass          http://dpla_portal;
 
@@ -179,9 +183,9 @@ server {
         proxy_no_cache            $http_cache_bypass $cookie_wordpress_logged_in;
 
         # Up to 10 simultaneous page requests per IP
-        limit_conn pageconnzone 10;
+        limit_conn defaultconnzone 10;
         # Up to 20 requests / sec for pages.
-        limit_req zone=pagereqzone burst=20;
+        limit_req zone=defaultreqzone burst={{ nginx_default_req_burst_size }};
         if ($http_cookie ~* "comment_author_|wordpress_(?!test_cookie)|wp-postpass_" ) {
             set $do_not_cache 1;
         }
@@ -233,8 +237,8 @@ server {
 
         location ~* \/[^\/]+\/(feed|\.xml)\/? {
             proxy_cache_valid 200 240m;
-            limit_conn pageconnzone 3;
-            limit_req zone=pagereqzone burst=16;
+            limit_conn defaultconnzone 3;
+            limit_req zone=defaultreqzone burst={{ nginx_default_req_burst_size }};
             if ($http_cookie ~* "comment_author_|wordpress_(?!test_cookie)|wp-postpass_" ) {
                 set $do_not_cache 1;
             }
@@ -265,9 +269,9 @@ server {
         }
 
         # Up to 10 simultaneous page requests per IP
-        limit_conn pageconnzone 10;
+        limit_conn defaultconnzone 10;
         # Up to 20 requests / sec for pages.
-        limit_req zone=pagereqzone burst=20;
+        limit_req zone=defaultreqzone burst={{ nginx_default_req_burst_size }};
 
         # For client_max_body_size, see the Omeka role's NGINX virtual host
         # configuration.

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -76,7 +76,15 @@ map $whitelisted $addr_to_limit {
 # For memory usage explanation, see:
 #  http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone
 limit_conn_zone $addr_to_limit zone=defaultconnzone:{{ nginx_conn_zone_size }};
-limit_req_zone  $addr_to_limit zone=defaultreqzone:{{ nginx_req_zone_size }} rate={{ nginx_default_req_sec }}r/s;
+limit_req_zone  $addr_to_limit zone=defaultreqzone:{{ nginx_req_zone_size }} rate={{ nginx_default_req_rate }};
+
+# Connection and request zones for locations defined below.
+limit_req_zone $addr_to_limit zone=bookshelfreq:{{ nginx_bookshelf_req_zone_size }} rate={{ nginx_bookshelf_req_rate }};
+limit_conn_zone $addr_to_limit zone=bookshelfconn:{{ nginx_bookshelf_conn_zone_size }};
+
+# Connection and rate-limiting log levels
+limit_conn_log_level {{ nginx_limit_conn_log_level }};
+limit_req_log_level {{ nginx_limit_req_log_level }};
 
 {% if ingestion2 is not defined %}
 
@@ -135,7 +143,7 @@ server {
         proxy_ignore_headers Cache-Control Set-Cookie;
 
         # Up to 10 simultaneous page requests per IP 
-        limit_conn defaultconnzone 10;
+        limit_conn defaultconnzone {{ nginx_default_max_conn }};
         # Up to 20 requests / sec for pages.
         limit_req zone=defaultreqzone burst={{ nginx_default_req_burst_size }};
     
@@ -164,6 +172,17 @@ server {
         {% endif %}
     }
 
+    location = /bookshelf {
+        # These proxy-related directives must appear here although they seem
+        # redundant with `location /` above.
+        proxy_cache_valid 200 240m;
+        proxy_ignore_headers Cache-Control Set-Cookie;
+        proxy_pass http://dpla_portal;
+
+        limit_req zone=bookshelfreq burst={{ nginx_default_req_burst_size }};
+        limit_conn bookshelfconn {{ nginx_bookshelf_max_conn }};
+    }
+
     location ~ ^/api/(.*)$ {
          add_header 'Access-Control-Allow-Origin' '*';
          rewrite ^/api/(.*)$ http://{{ api_hostname }}/$1 last;
@@ -180,7 +199,7 @@ server {
         proxy_no_cache            $http_cache_bypass $cookie_wordpress_logged_in;
 
         # Up to 10 simultaneous page requests per IP
-        limit_conn defaultconnzone 10;
+        limit_conn defaultconnzone {{ nginx_default_max_conn }};
         # Up to 20 requests / sec for pages.
         limit_req zone=defaultreqzone burst={{ nginx_default_req_burst_size }};
         if ($http_cookie ~* "comment_author_|wordpress_(?!test_cookie)|wp-postpass_" ) {
@@ -266,7 +285,7 @@ server {
         }
 
         # Up to 10 simultaneous page requests per IP
-        limit_conn defaultconnzone 10;
+        limit_conn defaultconnzone {{ nginx_default_max_conn }};
         # Up to 20 requests / sec for pages.
         limit_req zone=defaultreqzone burst={{ nginx_default_req_burst_size }};
 

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -64,9 +64,6 @@ map $http_content_type $do_not_cache {
 geo $whitelisted {
     default 1;
     127.0.0.1/32 0;
-    140.247.0.0/16 0; #harvard
-    23.22.230.215/32 0;
-    23.23.40.181/32 0;
 }
 
 map $whitelisted $addr_to_limit {


### PR DESCRIPTION
This changeset adds a few preliminary changes for parameterizing existing rate-limiting directives, and improving logging.  It then adds rate-limiting directives to place specific controls on the bookshelf, which makes relatively expensive search queries with lots of facets.
