### PR TITLE
Disable proxy caching of bookshelf

### DIFF
--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -173,10 +173,13 @@ server {
     }
 
     location = /bookshelf {
-        # These proxy-related directives must appear here although they seem
+        # Any proxy-related directives must appear here although they may seem
         # redundant with `location /` above.
-        proxy_cache_valid 200 240m;
-        proxy_ignore_headers Cache-Control Set-Cookie;
+        proxy_cache off;
+        # TODO:  consider selective caching, but watch out for Content-Type
+        # proxy_cache_valid 200 240m;
+        # proxy_ignore_headers Cache-Control Set-Cookie;
+        # proxy_cache_key       "$request_uri$http_content_type";
         proxy_pass http://dpla_portal;
 
         limit_req zone=bookshelfreq burst={{ nginx_default_req_burst_size }};


### PR DESCRIPTION
TODO: determine whether and how to cache bookshelf responses.

HTML and JSON responses were being cached under the same
proxy_cache_key, leading to JSON being returned for the main bookshelf
page.  If caching is enabled, it should use the suggested
proxy_cache_key value to ensure that JSON and HTML do not get mixed up.

This is related to the frontend's design decision to have the same
resource return not only different representations given different
Accept: content types, but different objects (data), as well.