### PR TITLE
Add playbooks to configure frontend app

### DIFF
--- a/ansible/playbooks/frontend.yml
+++ b/ansible/playbooks/frontend.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Frontend (portal) site
+  hosts: webapps
+  sudo: yes
+  roles:
+    - frontend
+  vars_files:
+    - ["../vars/{{ level }}.yml", "../vars/defaults.yml"]

--- a/ansible/playbooks/frontend_development.yml
+++ b/ansible/playbooks/frontend_development.yml
@@ -1,0 +1,3 @@
+---
+
+- include: frontend.yml level=development

--- a/ansible/playbooks/frontend_production.yml
+++ b/ansible/playbooks/frontend_production.yml
@@ -1,0 +1,3 @@
+---
+
+- include: frontend.yml level=staging

--- a/ansible/playbooks/frontend_staging.yml
+++ b/ansible/playbooks/frontend_staging.yml
@@ -1,0 +1,3 @@
+---
+
+- include: frontend.yml level=staging


### PR DESCRIPTION
Add playbooks to provision and configure the operating environment and
services surrounding the frontend app.

A playbook already existed to deploy the frontend, but there was no
playbook dedicated to configuring Unicorn, NGINX, package dependencies,
and so on.

This playbook runs everything for the frontend role, so it will
configure as well as deploy it.