### PR TITLE
Set dpla account's RAILS_ENV for ingestion app

### DIFF
--- a/ansible/roles/ingestion_app/tasks/main.yml
+++ b/ansible/roles/ingestion_app/tasks/main.yml
@@ -31,6 +31,14 @@
   tags:
     - users
 
+- name: Ensure that dpla user has correct RAILS_ENV
+  lineinfile: >-
+    dest=/home/dpla/.bashrc
+    regexp='RAILS_ENV='
+    line="export RAILS_ENV={{ rails_env }}"
+  tags:
+   - users
+
 - name: Ensure that the 'god' gem is installed for worker process management
   gem: >-
     name=god state=latest user_install=no


### PR DESCRIPTION
This is significant in production, or wherever the RAILS_ENV should not be the default, `development`.  If you are using the wrong RAILS_ENV (e.g. `development` on a production system), various settings could be off; for example (in my experience) you might enqueue jobs that get sent to the wrong redis queue, where they will not be picked up by the workers, (e.g. which are listening on the `production` queue).