### PR TITLE
Add memcached restart to frontend deployment

### DIFF
--- a/ansible/roles/frontend/handlers/main.yml
+++ b/ansible/roles/frontend/handlers/main.yml
@@ -2,3 +2,8 @@
 
 - name: restart nginx
   service: name=nginx state=reloaded
+
+- name: restart memcached
+  delegate_to: "{{ item }}"
+  with_items: groups.memcached
+  service: name=memcached state=restarted

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -133,6 +133,7 @@
   script: >
       build_frontend.sh {{ ruby_rbenv_version }}
   sudo_user: dpla
+  notify: restart memcached
   tags:
     - deployment
     - frontend


### PR DESCRIPTION
The frontend app. is configured in settings.local to use memcached.  It seemed to help last week when troubleshooting the frontend app to restart memcached at one point.
