### PR TITLE
Temporarily disable marmotta db tuning script

### DIFF
--- a/ansible/roles/marmotta/files/tunedb.sh
+++ b/ansible/roles/marmotta/files/tunedb.sh
@@ -55,6 +55,8 @@ set_column_statistics triples subject 5000
 set_column_statistics triples predicate 300
 set_column_statistics triples object 500
 
+# FIXME:  this is not one-size-fits-all.  The tablespace names
+# need to be gathered and iterated over.
 query 'ALTER TABLESPACE marmotta_1 SET (seq_page_cost = 2)'
 
 create_index_if_absent idx_triples_c triples context

--- a/ansible/roles/marmotta/tasks/main.yml
+++ b/ansible/roles/marmotta/tasks/main.yml
@@ -55,9 +55,12 @@
       state=link owner=root group=root
   notify: restart nginx
 
-- name: Tune the 'marmotta' database for our usage patterns
-  script: tunedb.sh
-  sudo_user: postgres
-  delegate_to: "{{ groups.postgresql_dbs[0] }}"
-  tags:
-    - tuning
+# FIXME: This needs to be better-automated.
+#        The tablespace names need to be determined dynamically.
+#
+# - name: Tune the 'marmotta' database for our usage patterns
+#   script: tunedb.sh
+#   sudo_user: postgres
+#   delegate_to: "{{ groups.postgresql_dbs[0] }}"
+#   tags:
+#     - tuning


### PR DESCRIPTION
Disable this script, because it should not work on a new installation,
where tablespaces have not been created.  Tablespace creation is still
something under the manual control of a DBA.  The script is just
disabled now, and needs to be modified to iterate over existing
tablespaces, if they exist.

The tuning script has been preserved, of course, and is still useful if it's copied and modified.