### PR TITLE
Expect Ansible 1.9, plus other fixes

### DIFF
--- a/README-ingestion2.md
+++ b/README-ingestion2.md
@@ -32,7 +32,8 @@ $ cd /dir/with/Vagrantfile
 $ vagrant up
 $ cd ansible
 ```
-An initial run to add your admin shell account to the VMs:
+An initial run to add your admin shell account to the VMs, noting the tip about
+`$HOME/.ssh/known_hosts` in [README.md](README.md):
 ```
 $ ansible-playbook -i ingestion -u vagrant \
   --private-key=$HOME/.vagrant.d/insecure_private_key dev_ingestion_all.yml \
@@ -42,8 +43,10 @@ Then some more invocations to configure everything:
 ```
 $ ansible-playbook -i ingestion -u <your username in group_vars/all> \
   playbooks/package_upgrade.yml
+$ vagrant reload
 $ ansible-playbook -i ingestion -u <your username in group_vars/all> \
   dev_ingestion_all.yml --extra-vars "initial_run=true"
+$ vagrant reload
 ```
 
 The various sites will be online at:

--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ Then some more invocations to configure everything:
 ```
 $ ansible-playbook -i development -u <your username in group_vars/all> \
   playbooks/package_upgrade.yml
+$ vagrant reload
 $ ansible-playbook -i development -u <your username in group_vars/all> \
   dev_all.yml --extra-vars "initial_run=true"
+$ vagrant reload
 ```
 
 The various sites will be online at:
@@ -96,6 +98,7 @@ The various sites will be online at:
 * http://local.dp.la/
 * http://local.dp.la/exhibitions/
 * http://local.dp.la:8080/v2/items (the API)
+* http://webapp1:8004/munin/  (resource monitoring graphs)
 
 
 However, there won't be any data ingested until you run an ingestion with
@@ -189,6 +192,13 @@ might use Docker, keeping in mind our need to represent our network setup.
 * The first time you create a VM, it has to do an extensive package upgrade
   of the the software in the base image, after which you should restart the VM
   with "vagrant reload".
+* If you notice that your VirtualBox processes on your host computer are using a
+  lot of CPU after creating new VMs, this is probably becuase the Munin resource
+  monitoring tool's statistics gatherer (`munin-node`) is running endlessly.  We
+  have not diagnosed what cuases this, but the easy solution is to make sure you
+  have run `vagrant reload` as suggested above in Installation > Steps.
+  Restarting the `munin-node` service on each host or rebooting the VMs seems to
+  fix the problem.
 * You probably want to exclude `$HOME/VirtualBox VMs/` from any backup jobs that
   you have going on.  The VMs can be recreated at any time, as long as you
   aren't storing data that can't be regenerated.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please install the following tools as documented on their websites:
 * [VirtualBox](https://www.virtualbox.org/) (Version 4.3)
 * [Vagrant](http://www.vagrantup.com/) (Version 1.6)
 * [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest/) (`vagrant plugin install vagrant-vbguest`)
-* [Ansible](http://www.ansible.com/) (Version 1.8) [installation instructions](http://docs.ansible.com/intro_installation.html)
+* [Ansible](http://www.ansible.com/) (Version 1.9) [installation instructions](http://docs.ansible.com/intro_installation.html)
 * Additional dependencies described in the `pip` requirements file (see below)
 
 ### Steps

--- a/ansible/roles/api/tasks/deploy.yml
+++ b/ansible/roles/api/tasks/deploy.yml
@@ -12,10 +12,11 @@
 - file: path=/home/dpla/api state=absent
 
 - name: Check out api (platform) app from its repository (git)
-  git: >
+  git: >-
       repo=https://github.com/dpla/platform.git
       dest=/home/dpla/api-git
       version={{ api_branch_or_tag | default("master") }}
+      force=true
   sudo_user: dpla
   when: not api_use_local_source
   tags:

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -12,10 +12,11 @@
 - file: path=/home/dpla/frontend state=absent
 
 - name: Check out frontend app from its repository
-  git: >
+  git: >-
       repo=https://github.com/dpla/frontend.git
       dest=/home/dpla/frontend-git
       version={{ frontend_branch_or_tag }}
+      force=true
   sudo_user: dpla
   when: not frontend_use_local_source
   tags:

--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -90,6 +90,7 @@
       repo=https://github.com/dpla/heidrun.git
       dest=/home/dpla/heidrun-git
       version={{ heidrun_branch_or_tag }}
+      force=true
   sudo_user: dpla
   when: not ingestion_use_local_source
 
@@ -98,6 +99,7 @@
       repo=https://github.com/dpla/heidrun-mappings.git
       dest=/home/dpla/heidrun-mappings-git
       version={{ heidrun_mappings_branch_or_tag }}
+      force=true
   sudo_user: dpla
   when: not ingestion_use_local_source
 

--- a/ansible/roles/omeka/tasks/deploy.yml
+++ b/ansible/roles/omeka/tasks/deploy.yml
@@ -12,10 +12,11 @@
 - file: path=/home/dpla/exhibitions state=absent
 
 - name: Check out exhibitions app from its repository (git)
-  git: >
+  git: >-
       repo=https://github.com/dpla/exhibitions.git
       dest=/home/dpla/exhibitions-git
       version={{ exhibitions_branch_or_tag | default("master") }}
+      force=true
   sudo_user: dpla
   when: not exhibitions_use_local_source
   tags:
@@ -78,10 +79,11 @@
     - web
 
 - name: Check out exhibitions assets
-  git: >
+  git: >-
        repo=https://github.com/dpla/exhibitions-assets.git
        dest="/home/dpla/exhibitions-assets"
        version=master
+       force=true
   sudo_user: dpla
   tags:
     - deployment

--- a/ansible/roles/solr/files/install_solr.sh
+++ b/ansible/roles/solr/files/install_solr.sh
@@ -42,7 +42,7 @@ test -z "$VERSION" && usage 1
 
 if solr_home_absent; then
     tarfile_name="$solrversion.tgz"
-    dl_base="http://mirrors.ibiblio.org/apache/lucene/solr/$VERSION"
+    dl_base="http://archive.apache.org/dist/lucene/solr/$VERSION"
     dl_url="$dl_base/$tarfile_name"
     cd /var/tmp
     wget -q $dl_url || err_exit "Could not get $dl_url"


### PR DESCRIPTION
This PR fixes a few things:

* We expect Ansible 1.9, which is to say, we don't fail when run with this version.   The documentation has been updated to reflect 1.9 as the expected version, and the `git` module invocations have been updated to use `force=true`, because the default for that module changed between `1.8` and `1.9`.  Ansible 1.9.2 contains an important security fix that affects any lower version.

* The download base URL for Solr is fixed.  It was only good for the most recent patchlevel of the desired version, leading to potential 404 errors when trying to download the package that's specified in our configuration.

* The README documentation has been improved with some advice on making installations run more smoothly.

These changes have been tested with Ansible 1.9, with:
* `ansible-lint`
* `ansible-playbook --syntax-check`
* with the legacy `development` inventory: with `ansible-playbook -i development dev_all.yml`, with existing and new VMs.
* with the new development inventory (`ingestion2`): with `ansible-playbook -i ingestion dev_ingestion_all.yml`, with existing and new VMs.

Those tests were performed with the Marmotta database tuning script disabled, in anticipation of https://github.com/dpla/automation/pull/106 being merged.
