### PR TITLE
Change rsync paths for heidrun-mappings

### DIFF
--- a/ansible/roles/ingestion_app/files/build_ingestion.sh
+++ b/ansible/roles/ingestion_app/files/build_ingestion.sh
@@ -65,10 +65,7 @@ echo "rsyncing mappings ..." >> $LOGFILE
 # Don't delete "extraneous" files in the destination directory, unlike the
 # other two rsync calls
 /usr/bin/rsync -rIptolg --checksum --delay-updates \
-    --exclude 'README.md' \
-    --exclude 'LICENSE' \
-    --exclude '.git*' \
-    /home/dpla/heidrun-mappings/ /opt/heidrun/vendor/mappings
+    /home/dpla/heidrun-mappings/heidrun /opt/heidrun/vendor/mappings
 if [ $? -ne 0 ]; then
     exit 1
 fi


### PR DESCRIPTION
Change the rsync path arguments in the build script for heidrun, so that
heidrun-mappings gets rsynced into place without its top-level
directory's contents.  Only the `heidrun` directory needs to be
transferred, and the changes suggested by
https://github.com/dpla/heidrun-mappings/pull/28 will result in a `spec`
directory that will have files with `require` statements that will
result in load errors.