### PR TITLE
Fix rsync switches in Exhibitions and elsewhere

### DIFF
--- a/ansible/roles/api/files/build_api.sh
+++ b/ansible/roles/api/files/build_api.sh
@@ -19,7 +19,7 @@ rbenv rehash
 
 echo "rsync from home to /srv/www/api ..." >> $LOGFILE
 
-/usr/bin/rsync -rptolg --checksum --delete --delay-updates \
+/usr/bin/rsync -rIptolg --checksum --delete --delay-updates \
     --exclude 'var/log' \
     --exclude 'tmp' \
     --exclude '.git' \

--- a/ansible/roles/api/files/copy_local_app.sh
+++ b/ansible/roles/api/files/copy_local_app.sh
@@ -13,7 +13,7 @@ if [ ! -d /home/dpla/api-local ]; then
 	mkdir /home/dpla/api-local
 fi
 
-rsync -rptl --delete --checksum \
+rsync -rIptl --delete --checksum \
     --exclude 'var/log' --exclude 'tmp' --exclude 'vendor/bundle' \
     /api_dev/ /home/dpla/api-local
 if [ $? -ne 0 ]; then

--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -30,7 +30,7 @@ echo "killing ssh_agent ..." >> $LOGFILE
 kill $SSH_AGENT_PID
 
 echo "rsync home to /srv/www ..." >> $LOGFILE
-/usr/bin/rsync -rptogl --checksum --delete --delay-updates \
+/usr/bin/rsync -rIptogl --checksum --delete --delay-updates \
     --exclude 'log' \
     --exclude 'tmp' \
     --exclude '.git' \

--- a/ansible/roles/frontend/files/copy_local_app.sh
+++ b/ansible/roles/frontend/files/copy_local_app.sh
@@ -13,7 +13,7 @@ if [ ! -d /home/dpla/frontend-local ]; then
 	mkdir /home/dpla/frontend-local
 fi
 
-rsync -rptl --delete --checksum \
+rsync -rIptl --delete --checksum \
     --exclude 'log' --exclude 'tmp' --exclude 'vendor/assets' \
     --exclude 'public/uploads' \
     /frontend_dev/ /home/dpla/frontend-local

--- a/ansible/roles/ingestion_app/files/build_ingestion.sh
+++ b/ansible/roles/ingestion_app/files/build_ingestion.sh
@@ -50,7 +50,7 @@ fi
 
 echo "rsyncing to /opt/heidrun ..." >> $LOGFILE
 
-/usr/bin/rsync -rptolg --checksum --delete --delay-updates \
+/usr/bin/rsync -rIptolg --checksum --delete --delay-updates \
     --exclude 'log' \
     --exclude 'tmp' \
     --exclude '.git' \
@@ -63,7 +63,7 @@ echo "rsyncing mappings ..." >> $LOGFILE
 
 # Don't delete "extraneous" files in the destination directory, unlike the
 # other two rsync calls
-/usr/bin/rsync -rptolg --checksum --delay-updates \
+/usr/bin/rsync -rIptolg --checksum --delay-updates \
     --exclude 'README.md' \
     --exclude 'LICENSE' \
     --exclude '.git*' \

--- a/ansible/roles/ingestion_app/files/copy_local_app.sh
+++ b/ansible/roles/ingestion_app/files/copy_local_app.sh
@@ -30,16 +30,16 @@ if [ ! -d /home/dpla/heidrun-mappings-local ]; then
     mkdir /home/dpla/heidrun-mappings-local
 fi
 
-rsync -rptl --delete --checksum \
+rsync -rIptl --delete --checksum \
     --exclude '.git*' /krikri/ /home/dpla/krikri \
     || exit 1
 
-rsync -rptl --delete --checksum \
+rsync -rIptl --delete --checksum \
     --exclude '.git*' --exclude 'log' \
     /heidrun/ /home/dpla/heidrun-local \
     || exit 1
 
-rsync -rptl --delete --checksum \
+rsync -rIptl --delete --checksum \
     --exclude '.git*' --exclude 'README.md' --exclude 'LICENSE' \
     /heidrun-mappings/ /home/dpla/heidrun-mappings-local \
     || exit 1

--- a/ansible/roles/omeka/files/build_exhibitions.sh
+++ b/ansible/roles/omeka/files/build_exhibitions.sh
@@ -5,7 +5,7 @@ LOGFILE=/tmp/build_exhibitions.log
 echo "starting." > $LOGFILE
 
 echo "rsync home to /srv/www ..." >> $LOGFILE
-/usr/bin/rsync -ruptolgC --delete --delay-updates \
+/usr/bin/rsync -rIptolgC --delete --checksum --delay-updates \
     --exclude 'themes/dpla/exhibitions-assets' \
     --exclude 'application/logs' \
     --exclude 'files' \
@@ -17,7 +17,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "rsync exhibitions-assets ..." >> $LOGFILE
-/usr/bin/rsync -ruptolgC --delete --delay-updates \
+/usr/bin/rsync -rIptolgC --delete --checksum --delay-updates \
     /home/dpla/exhibitions-assets/ /srv/www/exhibitions/themes/dpla/exhibitions-assets
 
 echo "done." >> $LOGFILE

--- a/ansible/roles/omeka/files/copy_local_app.sh
+++ b/ansible/roles/omeka/files/copy_local_app.sh
@@ -13,7 +13,7 @@ if [ ! -d /home/dpla/exhibitions-local ]; then
   mkdir /home/dpla/exhibitions-local
 fi
 
-rsync -rptl --delete --checksum \
+rsync -rIptl --delete --checksum \
     --exclude 'application/logs' \
     /exhibitions_dev/ /home/dpla/exhibitions-local
 if [ $? -ne 0 ]; then

--- a/ansible/roles/wordpress/files/build_wordpress_local.sh
+++ b/ansible/roles/wordpress/files/build_wordpress_local.sh
@@ -6,7 +6,7 @@ rsync=/usr/bin/rsync
 
 cd $HOME
 
-$rsync -rptl --delete --checksum \
+$rsync -rIptl --delete --checksum \
     --exclude '.git' \
     --exclude 'wp-config.php' \
     --exclude 'wp-content/uploads' \

--- a/ansible/roles/wordpress/files/sync_to_siteroot.sh
+++ b/ansible/roles/wordpress/files/sync_to_siteroot.sh
@@ -3,7 +3,7 @@
 
 rsync=/usr/bin/rsync
 
-$rsync -rptogl --checksum --delete --delay-updates \
+$rsync -rIptogl --checksum --delete --delay-updates \
     --exclude 'wp-content/uploads' \
     --exclude 'wp-config.php' \
     --exclude '.git' \


### PR DESCRIPTION
Fix the options given to rsync in the Exhibitions build script, to make sure that it selects files based on their checksums.  Timestamps must be ignored due to potential problems in development if one switches back and forth between locally-modified and downloaded copies of files.

Elsewhere, in other scripts, the -I (ignore timestamp) option has been added just for clarity, even when timestamps would have been ignored due to the --checksum option being given.