### PR TITLE
Configure Tomcat plugin for Munin (fixes #7900)

### DIFF
--- a/ansible/roles/tomcat_common/defaults/main.yml
+++ b/ansible/roles/tomcat_common/defaults/main.yml
@@ -2,6 +2,8 @@
 
 tomcat_admin_username: tcadmin
 tomcat_admin_password: changeme
+tomcat_munin_username: tcmunin
+tomcat_munin_password: changememunin
 tomcat_max_mem_mb: 256
 tomcat_init_mem_mb: 256
 

--- a/ansible/roles/tomcat_common/handlers/main.yml
+++ b/ansible/roles/tomcat_common/handlers/main.yml
@@ -2,3 +2,6 @@
 
 - name: restart tomcat
   service: name=tomcat7 state=restarted
+
+- name: restart munin-node
+  service: name=munin-node state=restarted

--- a/ansible/roles/tomcat_common/tasks/main.yml
+++ b/ansible/roles/tomcat_common/tasks/main.yml
@@ -2,6 +2,8 @@
 
 - include_vars: "../vars/{{ level }}.yml"
   when: level is defined
+  tags:
+    - munin
 
 - name: Make sure that the Tomcat packages are installed
   apt: name={{ item }} state=present
@@ -45,3 +47,34 @@
     mode=0644 owner=root group=root
   tags:
     - logs
+
+## Tomcat Munin plugins
+#
+
+- name: Make sure Perl XML::Simple module is installed
+  apt: pkg=libxml-simple-perl state=present
+  tags:
+    - munin
+    - packages
+
+- name: Ensure state of configuration for Munin Tomcat plugin
+  template: >-
+      src=etc_munin_plugin_conf_d_zzz-tomcat.j2
+      dest=/etc/munin/plugin-conf.d/zzz-tomcat
+      owner=root group=root mode=0644
+  notify: restart munin-node
+  tags:
+    - munin
+
+- name: Symlink basic Munin Tomcat plugins
+  file: >-
+    src="/usr/share/munin/plugins/{{ item }}"
+    dest="/etc/munin/plugins/{{ item }}"
+    state=link
+  with_items:
+    - tomcat_access
+    - tomcat_jvm
+    - tomcat_threads
+    - tomcat_volume
+  tags:
+    - munin

--- a/ansible/roles/tomcat_common/templates/etc_munin_plugin_conf_d_zzz-tomcat.j2
+++ b/ansible/roles/tomcat_common/templates/etc_munin_plugin_conf_d_zzz-tomcat.j2
@@ -1,0 +1,6 @@
+[tomcat_*]
+env.ports 8080
+env.user {{ tomcat_munin_username }}
+env.password {{ tomcat_munin_password }}
+env.host {{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['address'] }}
+env.connector "http-bio-{{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['address'] }}-8080"

--- a/ansible/roles/tomcat_common/templates/tomcat-users.xml.j2
+++ b/ansible/roles/tomcat_common/templates/tomcat-users.xml.j2
@@ -6,4 +6,6 @@
   <role rolename="manager-gui" />
   <user username="{{ tomcat_admin_username }}" password="{{ tomcat_admin_password }}"
         roles="manager-gui,admin-gui,manager,admin" />
+  <user username="{{ tomcat_munin_username }}" password="{{ tomcat_munin_password }}"
+        roles="manager-status,manager" />
 </tomcat-users>


### PR DESCRIPTION
* Adds a `tcmunin` user for Tomcat that only has access to the status pages in Tomcat Manager.
* Add Munin plugin-related tasks for Tomcat (installs dependencies, builds template to generate plugin configuration, and symlinks plugins into appropriate location).