### PR TITLE
Revert "Add NGINX keepalive, marmotta proxy" (refs #7903)

### DIFF
--- a/ansible/roles/marmotta/templates/etc_nginx_sites-available_marmotta.j2
+++ b/ansible/roles/marmotta/templates/etc_nginx_sites-available_marmotta.j2
@@ -1,14 +1,4 @@
 
-upstream marmotta {
-    server {{ inventory_hostname }}:8080 max_conns=200;
-
-    # Is this good?  How many connections will Tomcat support?
-    # What is the best keepalive value?
-    # See https://tomcat.apache.org/tomcat-7.0-doc/config/http.html
-    # See http://java.dzone.com/articles/understanding-tomcat-nio
-    keepalive 100;
-}
-
 server {
 
     listen 80;
@@ -36,7 +26,7 @@ server {
         proxy_set_header X-Forwarded-Proto http;
         proxy_set_header Host $http_host;
         proxy_pass_header Set-Cookie;
-        proxy_pass http://marmotta;
+        proxy_pass http://{{ inventory_hostname }}:8080/;
         proxy_redirect default;
         proxy_read_timeout 600s;
         proxy_send_timeout 600s;


### PR DESCRIPTION
This reverts commit bcc646c3ab06688f034561997728722bbe500245.

dpla/automation#104 (Add NGINX keepalive, marmotta proxy) introduced an issue wherein upon nginx starting, it spits out an error:

```
2015/08/26 19:12:48 [emerg] 21963#0: invalid parameter "max_conns=200" in /etc/nginx/sites-enabled/marmotta:3
```

`max_conns` is only available with Nginx Plus (their commercial offering) based upon the subtle message in the documentation:
<http://nginx.org/en/docs/http/ngx_http_upstream_module.html#down>