### PR TITLE
Clean up stale Unicorn files

### DIFF
--- a/ansible/roles/api/tasks/deploy.yml
+++ b/ansible/roles/api/tasks/deploy.yml
@@ -107,6 +107,19 @@
     - api_deployment
     - web
 
+- name: Assert that Unicorn pid and socket files are absent
+  # These could have been left behind by an earlier failure or termination
+  file: >-
+    path="/srv/www/api/tmp/unicorn_api.{{ item }}" state=absent
+  with_items:
+    - pid
+    - sock
+  tags:
+    - deployment
+    - api
+    - api_deployment
+    - web
+
 - name: Build api app
   script: >
       build_api.sh {{ ruby_rbenv_version }}

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -130,6 +130,19 @@
     - frontend_deployment
     - web
 
+- name: Assert that Unicorn pid and socket files are absent
+  # These could have been left behind by an earlier failure or termination
+  file: >-
+    path="/srv/www/frontend/tmp/unicorn_frontend.{{ item }}" state=absent
+  with_items:
+    - pid
+    - sock
+  tags:
+    - deployment
+    - frontend
+    - frontend_deployment
+    - web
+
 - name: Build frontend app
   script: >
       build_frontend.sh {{ ruby_rbenv_version }}

--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -183,6 +183,14 @@
   when: >-
     'ingestion_app' in hostvars[inventory_hostname]['group_names']
 
+- name: Assert that Unicorn pid and socket files are absent
+  # These could have been left behind by an earlier failure or termination
+  file: >-
+    path="/opt/heidrun/tmp/unicorn_heidrun.{{ item }}" state=absent
+  with_items:
+    - pid
+    - sock
+
 - name: Build web application (and copy to live directory)
   script: >-
     ../files/build_ingestion.sh "{{ '-f' if fast_deployment else '' }}" {{ ingestion_rbenv_version }}


### PR DESCRIPTION
Remove pid and socket files during deployments, after the shutdown step, in case these files were left around from an earlier failure.  Their presence will cause the startup to fail after the build step is complete.