### PR TITLE
Fix ruby bundle installations and upgrades

### DIFF
--- a/ansible/roles/api/files/build_api.sh
+++ b/ansible/roles/api/files/build_api.sh
@@ -14,7 +14,8 @@ rbenv shell $USE_VERSION
 
 echo "installing bundle ..." >> $LOGFILE
 
-bundle update
+rm -f Gemfile.lock
+bundle install
 rbenv rehash
 
 echo "rsync from home to /srv/www/api ..." >> $LOGFILE

--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -18,7 +18,8 @@ rbenv shell $USE_VERSION
 
 echo "installing bundle ..." >> $LOGFILE
 
-bundle update
+rm -f Gemfile.lock
+bundle install
 bundle update dpla_frontend_assets
 rbenv rehash
 

--- a/ansible/roles/ingestion_app/files/build_ingestion.sh
+++ b/ansible/roles/ingestion_app/files/build_ingestion.sh
@@ -44,7 +44,8 @@ rbenv global $use_version
 echo "installing bundle ..." >> $LOGFILE
 
 if [ $fast == 0 ]; then
-    bundle update || exit 1
+    rm -f Gemfile.lock
+    bundle install || exit 1
     rbenv rehash
 fi
 

--- a/ansible/roles/pss/files/build_pss.sh
+++ b/ansible/roles/pss/files/build_pss.sh
@@ -16,7 +16,7 @@ echo "using version ${USE_VERSION} ..." >> $LOGFILE
 echo "installing bundle ..." >> $LOGFILE
 
 rm -f Gemfile.lock
-bundle update >> $LOGFILE 2>&1
+bundle install >> $LOGFILE 2>&1
 rbenv rehash >> $LOGFILE 2>&1
 
 echo "precompiling assets ..." >> $LOGFILE


### PR DESCRIPTION
See https://issues.dp.la/issues/7840

This fixes issues with newly-added gems not installing, but ensures that deployments install the latest bugfix releases of correctly-pinned gems.