### PR TITLE
Improve PostgreSQL configuration for write performance

### DIFF
--- a/ansible/roles/marmotta/files/tunedb.sh
+++ b/ansible/roles/marmotta/files/tunedb.sh
@@ -60,3 +60,11 @@ set_column_statistics triples object 500
 query 'ALTER TABLESPACE marmotta_1 SET (seq_page_cost = 2)'
 
 create_index_if_absent idx_triples_c triples context
+
+# TODO: issue the following queries dependent upon the row count of the tables.
+# This should be something you can re-run as the tables grow.
+#
+# query 'alter table triples set (autovacuum_vacuum_scale_factor = 0.05)'
+# query 'alter table triples set (autovacuum_analyze_scale_factor=0.025);'
+# query 'alter table nodes set (autovacuum_vacuum_scale_factor = 0.05)'
+# query 'alter table nodes set (autovacuum_analyze_scale_factor=0.025);'

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 postgresql_user: {name: "dpla", password: "changeme"}
+# These memory-related values are tuned to the size of the development VM.
 pg_max_connections: 50
 pg_shared_buffers: 24MB
 pg_effective_cache_size: 128MB
@@ -9,6 +10,19 @@ pg_maintenance_work_mem: 16MB
 # The default random_page_cost of 4.0 assumes you're using disks.
 # Decrease it if you're using SSD drives.  1.5 might be a good value.
 pg_random_page_cost: 4.0
+# default for bgwriter_delay is 200ms
+pg_bgwriter_delay: 200ms
+# default for bgwriter_lru_maxpages is 100
+pg_bgwriter_lru_maxpages: 100
+# default for bgwriter_lru_multiplier is 2.0
+pg_bgwriter_lru_multiplier: 2.0
+# default for checkpoint_segments is 3
+pg_checkpoint_segments: 32
+# default for checkpoint_timeout is 5min
+pg_checkpoint_timeout: 10min
+# default for checkpoint_completion_target is 0.5
+pg_checkpoint_completion_target: 0.9
+
 pg_backup_keep_days: 7
 pg_log_min_duration_statement: 100
 backups_basedir: /backups

--- a/ansible/roles/postgresql/templates/postgresql.conf.j2
+++ b/ansible/roles/postgresql/templates/postgresql.conf.j2
@@ -135,9 +135,9 @@ maintenance_work_mem = {{ pg_maintenance_work_mem }}		# min 1MB
 
 # - Background Writer -
 
-#bgwriter_delay = 200ms				# 10-10000ms between rounds
-#bgwriter_lru_maxpages = 100		# 0-1000 max buffers written/round
-#bgwriter_lru_multiplier = 2.0		# 0-10.0 multipler on buffers scanned/round
+bgwriter_delay = {{ pg_bgwriter_delay }}				# 10-10000ms between rounds
+bgwriter_lru_maxpages = {{ pg_bgwriter_lru_maxpages }}		# 0-1000 max buffers written/round
+bgwriter_lru_multiplier = {{ pg_bgwriter_lru_multiplier }}		# 0-10.0 multipler on buffers scanned/round
 
 # - Asynchronous Behavior -
 
@@ -171,9 +171,9 @@ wal_writer_delay = 500ms		# 1-10000 milliseconds
 
 # - Checkpoints -
 
-checkpoint_segments = 32		# in logfile segments, min 1, 16MB each
-#checkpoint_timeout = 5min		# range 30s-1h
-checkpoint_completion_target = 0.9	# checkpoint target duration, 0.0 - 1.0
+checkpoint_segments = {{ pg_checkpoint_segments }}		# in logfile segments, min 1, 16MB each
+checkpoint_timeout = {{ pg_checkpoint_timeout }}		# range 30s-1h
+checkpoint_completion_target = {{ pg_checkpoint_completion_target }}	# checkpoint target duration, 0.0 - 1.0
 #checkpoint_warning = 30s		# 0 disables
 
 # - Archiving -
@@ -368,7 +368,7 @@ log_min_duration_statement = {{ pg_log_min_duration_statement }}	# -1 is disable
 #debug_print_rewritten = off
 #debug_print_plan = off
 #debug_pretty_print = on
-#log_checkpoints = off
+log_checkpoints = on
 #log_connections = off
 #log_disconnections = off
 #log_duration = off
@@ -394,7 +394,7 @@ log_line_prefix = '%t '			# special values:
 								#        processes
 								#   %% = '%'
 								# e.g. '<%u%%%d> '
-#log_lock_waits = off			# log lock waits >= deadlock_timeout
+log_lock_waits = on 			# log lock waits >= deadlock_timeout
 #log_statement = 'none'			# none, ddl, mod, all
 log_temp_files = 0				# log temporary files equal or larger
 								# than the specified size in kilobytes;
@@ -430,7 +430,7 @@ log_temp_files = 0				# log temporary files equal or larger
 
 #autovacuum = on						# Enable autovacuum subprocess?  'on'
 										# requires track_counts to also be on.
-#log_autovacuum_min_duration = -1		# -1 disables, 0 logs all actions and
+log_autovacuum_min_duration = 0			# -1 disables, 0 logs all actions and
 										# their durations, > 0 logs only
 										# actions running at least this number
 										# of milliseconds.
@@ -448,7 +448,7 @@ log_temp_files = 0				# log temporary files equal or larger
 #autovacuum_vacuum_cost_delay = 20ms	# default vacuum cost delay for
 										# autovacuum, in milliseconds;
 										# -1 means use vacuum_cost_delay
-#autovacuum_vacuum_cost_limit = -1		# default vacuum cost limit for
+autovacuum_vacuum_cost_limit = 150		# default vacuum cost limit for
 										# autovacuum, -1 means use
 										# vacuum_cost_limit
 
@@ -511,7 +511,7 @@ default_text_search_config = 'pg_catalog.english'
 # LOCK MANAGEMENT
 #------------------------------------------------------------------------------
 
-#deadlock_timeout = 1s
+deadlock_timeout = 8s
 #max_locks_per_transaction = 64			# min 10
 										# (change requires restart)
 # Note:  Each lock table slot uses ~270 bytes of shared memory, and there are


### PR DESCRIPTION
Add variables for some PostgreSQL configuration settings -- and adjust others -- that govern write performance. Change the configuration of the `bgwriter`, checkpointing, and locking. Enable logging for locks, checkpoints, and autovacuuming.

This has been tested with our `development` and `ingestion` inventories to the extent of making sure the playbook runs successfully. The settings have been used in our staging and production environments, with overrides for certain variables.
