### PR TITLE
Set RAILS_ENV when running Rails 4.x build scripts

### DIFF
--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -196,6 +196,8 @@
     ../files/build_ingestion.sh "{{ '-f' if fast_deployment else '' }}" {{ ingestion_rbenv_version }}
     {{ hostvars[inventory_hostname]['group_names'] | join(',') }}
   sudo_user: dpla
+  environment:
+    RAILS_ENV: "{{ pss_rails_env }}"
 
 - name: Start Unicorn
   service: name=unicorn_heidrun state=started

--- a/ansible/roles/pss/tasks/deploy.yml
+++ b/ansible/roles/pss/tasks/deploy.yml
@@ -91,6 +91,8 @@
   script: >-
     build_pss.sh "{{ pss_rbenv_version }}"
   sudo_user: dpla
+  environment:
+    RAILS_ENV: "{{ pss_rails_env }}"
 
 - name: Ensure existence of uploads directory
   file: >-


### PR DESCRIPTION
This addresses issues where assets were not being loaded, e.g. for the
primary-source-sets application and Heidrun.