### PR TITLE
Add pss to roles that have turnout maintenance mode

### DIFF
--- a/ansible/playbooks/pg_maintenance_off.yml
+++ b/ansible/playbooks/pg_maintenance_off.yml
@@ -18,4 +18,13 @@
         path=/srv/www/frontend/tmp/maintenance.yml
         state=absent
 
+- name: Take Primary Source Sets out of maintenance mode
+  hosts: pss
+  sudo: true
+  tasks:
+    - name: Remove maintenance.yml file
+      file: >-
+        path=/srv/www/pss/tmp/maintenance.yml
+        state=absent
+
 - include: clear_proxy_cache.yml

--- a/ansible/playbooks/pg_maintenance_on.yml
+++ b/ansible/playbooks/pg_maintenance_on.yml
@@ -20,4 +20,14 @@
         dest=/srv/www/api/tmp/maintenance.yml
         owner=root group=root mode=0644
 
+- name: Put Primary Source Sets into maintenance mode
+  hosts: pss
+  sudo: true
+  tasks:
+    - name: Deploy turnout maintenance.yml file
+      copy: >-
+        src=../files/turnout_postgres_maintenance.yml
+        dest=/srv/www/pss/tmp/maintenance.yml
+        owner=root group=root mode=0644
+
 - include: clear_proxy_cache.yml


### PR DESCRIPTION
Add the Primary Source Sets app to those Rails apps that are connected to PostgreSQL and that need to be taken offline during PostgreSQL maintenance.