### PR TITLE
Fix variable name

### DIFF
--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -197,7 +197,7 @@
     {{ hostvars[inventory_hostname]['group_names'] | join(',') }}
   sudo_user: dpla
   environment:
-    RAILS_ENV: "{{ pss_rails_env }}"
+    RAILS_ENV: "{{ ingestion_app_rails_env }}"
 
 - name: Start Unicorn
   service: name=unicorn_heidrun state=started


### PR DESCRIPTION
Change `pss_rails_env` to `ingestion_app_rails_env`

Causes an error due to the variable not being defined when run with defaults (without it being overridden).
