### PR TITLE
Install frontend assets only if requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,4 +205,5 @@ might use Docker, keeping in mind our need to represent our network setup.
 * If you destroy and re-create a VM, you should delete the old public key
   from `$HOME/.ssh/known_hosts` to avoid getting an error when you run
   ansible-playbook again.  Look for the hostname in addition to its IP address.
-
+* See the note in group_vars/all.dist about using SSH private keys for deploying
+  from private GitHub repositories, if you intend to use private resources.

--- a/ansible/group_vars/all.dist
+++ b/ansible/group_vars/all.dist
@@ -20,6 +20,9 @@ iana_timezone: US/Eastern
 # is to set an alias for the ansible-playbook command, such as:
 #   $ alias ansible-playbook='ansible-playbook \
 #     -e "github_private_key_path=~/.ssh/id_rsa_github'
+# Note that this key file should not be password-protected.  We recommend that
+# you create a deployment-only ssh-key that's not password protected, that's
+# separate from the key that you'd normally use to log into your servers.
 # github_private_key_path: ~/.ssh/id_rsa
 
 ## The following variables are only relevant if you're using Amazon SES for mail

--- a/ansible/roles/frontend/defaults/main.yml
+++ b/ansible/roles/frontend/defaults/main.yml
@@ -7,4 +7,5 @@ frontend_use_local_source: false
 frontend_branch_or_tag: master
 frontend_s3_bucket: changeme
 frontend_alternate_db_host: false
+frontend_include_branding: false
 bookshelf_max_pages: 100

--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -1,34 +1,55 @@
 #!/bin/bash
 
+# Synopsis
+#
+# - Build with Ruby 1.9.3-p547, with dpla_frontend_assets gem
+#   build_frontend.sh 1.9.3-p547
+#
+# - Build as above, but with dpla_frontend_assets gem
+#   build_frontend.sh 1.9.3-p547 branding
+
+
 USE_VERSION=$1
+BRANDING=${2:-""}
 export PATH=$HOME/.rbenv/bin:$PATH
 LOGFILE=/tmp/build_frontend.log
 
 echo "starting" > $LOGFILE
 
 eval "`rbenv init -`" >> $LOGFILE 2>&1
-# Start ssh-agent and set environment variables.
-# Work-around for private GitHub repository in Gemfile.
-eval `ssh-agent`
-ssh-add $HOME/git_private_key  >> $LOGFILE 2>&1
+
+echo "rbenv initialized" >> $LOGFILE
+
+if [ "$BRANDING" == "branding" ]; then
+    # Start ssh-agent and set environment variables.
+    # Work-around for private GitHub repository in Gemfile.
+    echo "starting ssh-agent ..." >> $LOGFILE
+    eval `ssh-agent`
+    ssh-add $HOME/git_private_key  >> $LOGFILE 2>&1
+fi
 
 cd $HOME/frontend
 
 rbenv shell $USE_VERSION >> $LOGFILE 2>&1
+echo "using rbenv version $USE_VERSION" >> $LOGFILE
 
 echo "installing bundle ..." >> $LOGFILE
 
 rm -f Gemfile.lock
 bundle install >> $LOGFILE 2>&1
-bundle update dpla_frontend_assets >> $LOGFILE 2>&1
+if [ $? -ne 0 ]; then
+    exit 1
+fi
 rbenv rehash
 
 echo "precompiling assets ..." >> $LOGFILE
 bundle exec rake assets:precompile >> $LOGFILE 2>&1
 
-echo "killing ssh_agent ..." >> $LOGFILE
-# Variable set above by ssh-agent
-kill $SSH_AGENT_PID
+if [ "$BRANDING" == "branding" ]; then
+    echo "killing ssh_agent ..." >> $LOGFILE
+    # Variable set above by ssh-agent
+    kill $SSH_AGENT_PID
+fi
 
 echo "rsync home to /srv/www ..." >> $LOGFILE
 /usr/bin/rsync -rIptogl --checksum --delete --delay-updates \

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -43,6 +43,14 @@
       src=unicorn.rb.j2 dest=/home/dpla/frontend/config/unicorn.rb
       owner=dpla group=dpla mode=0644
 
+- name: Add dpla_frontend_assets to Gemfile if branding is turned on
+  lineinfile: >
+    dest=/home/dpla/frontend/Gemfile
+    state=present
+    regexp=dpla_frontend_assets
+    line="gem 'dpla_frontend_assets', git: 'git@github.com:dpla/frontend-assets.git'"
+  when: frontend_include_branding
+
 - name: Make sure rbenv and bundler are current
   script: >
       ../../../files/install_ruby_tools.sh {{ frontend_rbenv_version }}
@@ -63,6 +71,7 @@
       src={{ github_private_key_path | default("~/.ssh/id_rsa") }}
       dest=/home/dpla/git_private_key
       owner=dpla group=dpla mode=0600
+  when: frontend_include_branding
 
 - name: Stop Unicorn (gracefully)
   # Unicorn is stopped completely, and later restarted, because we assume that
@@ -81,8 +90,9 @@
     - sock
 
 - name: Build frontend app
-  script: >
+  script: >-
       build_frontend.sh {{ frontend_rbenv_version }}
+      {{ 'branding' if frontend_include_branding else '' }}
   sudo_user: dpla
   notify: restart memcached
 
@@ -101,3 +111,4 @@
 
 - name: Remove temporary private key for GitHub
   file: path=/home/dpla/git_private_key state=absent
+  when: frontend_include_branding

--- a/ansible/roles/pss/defaults/main.yml
+++ b/ansible/roles/pss/defaults/main.yml
@@ -26,3 +26,4 @@ pss_zencoder_notification_pass: OVERRIDE-THIS
 pss_zencoder_s3_credentials_name: false
 pss_contact_email: email@example.com
 pss_alternate_db_host: false
+pss_include_branding: false

--- a/ansible/roles/pss/files/build_pss.sh
+++ b/ansible/roles/pss/files/build_pss.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
 USE_VERSION=$1
+BRANDING=${2:-""}
 export PATH=$HOME/.rbenv/bin:$PATH
 LOGFILE=/tmp/build_pss.log
 
 echo "starting" > $LOGFILE
 
 eval "`rbenv init -`"
-# Start ssh-agent and set environment variables.
-# Work-around for private GitHub repository in Gemfile.
-eval `ssh-agent`
-ssh-add $HOME/git_private_key
+
+if [ "$BRANDING" == "branding" ]; then
+    # Start ssh-agent and set environment variables.
+    # Work-around for private GitHub repository in Gemfile.
+    eval `ssh-agent`
+    ssh-add $HOME/git_private_key
+fi
 
 cd /home/dpla/pss
 
@@ -21,14 +25,19 @@ echo "installing bundle ..." >> $LOGFILE
 
 rm -f Gemfile.lock
 bundle install >> $LOGFILE 2>&1
+if [ $? -ne 0 ]; then
+    exit 1
+fi
 rbenv rehash >> $LOGFILE 2>&1
 
 echo "precompiling assets ..." >> $LOGFILE
 bundle exec rake assets:precompile >> $LOGFILE 2>&1
 
-echo "killing ssh_agent ..." >> $LOGFILE
-# Variable set above by ssh-agent
-kill $SSH_AGENT_PID
+if [ "$BRANDING" == "branding" ]; then
+    echo "killing ssh_agent ..." >> $LOGFILE
+    # Variable set above by ssh-agent
+    kill $SSH_AGENT_PID
+fi
 
 echo "rsync from home to /srv/www/pss ..." >> $LOGFILE
 

--- a/ansible/roles/pss/tasks/deploy.yml
+++ b/ansible/roles/pss/tasks/deploy.yml
@@ -48,6 +48,14 @@
       src=unicorn.rb.j2 dest=/home/dpla/pss/config/unicorn.rb
       owner=dpla group=dpla mode=0644
 
+- name: Add dpla_frontend_assets to Gemfile if branding is turned on
+  lineinfile: >
+    dest=/home/dpla/pss/Gemfile
+    state=present
+    regexp=dpla_frontend_assets
+    line="gem 'dpla_frontend_assets', git: 'git@github.com:dpla/frontend-assets.git'"
+  when: pss_include_branding
+
 - name: Make sure that rbenv and bundler are current
   script: >-
       ../../../files/install_ruby_tools.sh {{ pss_rbenv_version }}
@@ -90,6 +98,7 @@
 - name: Build primary-source-sets app
   script: >-
     build_pss.sh "{{ pss_rbenv_version }}"
+    {{ 'branding' if pss_include_branding else '' }}
   sudo_user: dpla
   environment:
     RAILS_ENV: "{{ pss_rails_env }}"


### PR DESCRIPTION
Add the variable `frontend_include_branding`, which governs whether the private dpla_frontend_assets gem is included for branding-related assets.  This defuaults to false.

Addresses one of the problems raised in https://github.com/dpla/automation/issues/117

There's a known issue mentioned in the comments of `build_frontend.sh`, but this is as good as it gets for now.  This prevents non-DPLA staff from running into build errors.
