### PR TITLE
Add symlink to fix Solr startup error

### DIFF
--- a/ansible/roles/solr/files/install_solr.sh
+++ b/ansible/roles/solr/files/install_solr.sh
@@ -66,6 +66,8 @@ if solr_home_absent; then
     rm -rf /var/tmp/solr-$VERSION*
     cd /opt
     ln -sf $solrversion solr || err_exit "Could not symlink solr directory"
+    ln -sf /opt/solr/dpla/solr /var/lib/tomcat7/solr \
+        || err_exit "Could not symlink solr into /var/lib/tomcat7"
     changed=1
 fi
 


### PR DESCRIPTION
Add the symlink `/var/lib/tomcat7/solr -> /opt/solr/dpla/solr` to fix an error in starting up Solr.

This fixes a problem that errors out the provisioning of a new Ingestion 2 development VM.

Solr was complaining in the development environment that it could not locate /var/lib/tomcat7/solr/collection1/conf/solrconfig.xml, and this was causing it not to start.

Why this was never encountered before is a bit of a mystery, and our production and staging environments have got by without this symlink. It's possible that the change in behavior is either due to the development system on which this was encountered having the most up-to-date system packages as possible, having been newly-installed, and one of these introducing some kind of relevant change; or that there was some change related to the recent rearranging of `automation` variables, though we can't locate anything that was changed significantly in the `tomcat_common` or `solr` roles.
