### PR TITLE
Allow setting of non-inventory database host

### DIFF
--- a/ansible/playbooks/pg_maintenance_off.yml
+++ b/ansible/playbooks/pg_maintenance_off.yml
@@ -8,6 +8,7 @@
       file: >-
         path=/srv/www/api/tmp/maintenance.yml
         state=absent
+      when: not api_alternate_db_host | default(false)
 
 - name: Take frontend out of maintenance mode
   hosts: frontend
@@ -17,6 +18,7 @@
       file: >-
         path=/srv/www/frontend/tmp/maintenance.yml
         state=absent
+      when: not frontend_alternate_db_host | default(false)
 
 - name: Take Primary Source Sets out of maintenance mode
   hosts: pss
@@ -26,5 +28,6 @@
       file: >-
         path=/srv/www/pss/tmp/maintenance.yml
         state=absent
+      when: not pss_alternate_db_host | default(false)
 
 - include: clear_proxy_cache.yml

--- a/ansible/playbooks/pg_maintenance_on.yml
+++ b/ansible/playbooks/pg_maintenance_on.yml
@@ -9,6 +9,7 @@
         src=../files/turnout_postgres_maintenance.yml
         dest=/srv/www/frontend/tmp/maintenance.yml
         owner=root group=root mode=0644
+      when: not frontend_alternate_db_host | default(false)
 
 - name: Put API into maintenance mode
   hosts: api
@@ -19,6 +20,7 @@
         src=../files/turnout_postgres_maintenance.yml
         dest=/srv/www/api/tmp/maintenance.yml
         owner=root group=root mode=0644
+      when: not api_alternate_db_host | default(false)
 
 - name: Put Primary Source Sets into maintenance mode
   hosts: pss
@@ -29,5 +31,6 @@
         src=../files/turnout_postgres_maintenance.yml
         dest=/srv/www/pss/tmp/maintenance.yml
         owner=root group=root mode=0644
+      when: not pss_alternate_db_host | default(false)
 
 - include: clear_proxy_cache.yml

--- a/ansible/playbooks/reboot_postgresql.yml
+++ b/ansible/playbooks/reboot_postgresql.yml
@@ -1,6 +1,8 @@
 ---
 
 - include: pg_maintenance_on.yml
+# TODO:  When Ansible version 2 is stable, add a "where:" condition here so
+# so that the playbook is not even included if some condition is False.
 
 - name: Reboot PostgreSQL server
   hosts: postgresql_dbs
@@ -18,3 +20,4 @@
         port=5432 delay=40 timeout=600
 
 - include: pg_maintenance_off.yml
+# TODO: see above

--- a/ansible/roles/api/defaults/main.yml
+++ b/ansible/roles/api/defaults/main.yml
@@ -5,6 +5,7 @@ api_use_local_source: false
 api_branch_or_tag: master
 api_rails_env: development
 api_rbenv_version: 1.9.3-p547
+api_alternate_db_host: false
 qa_app_username: qa
 # password is "changeme"
 qa_app_md5_password: "$apr1$bTHb7fKA$glS0Kk6zI6ny0GW0hPerk/"

--- a/ansible/roles/api/templates/database.yml.j2
+++ b/ansible/roles/api/templates/database.yml.j2
@@ -1,6 +1,9 @@
 
-{# Assume there's just one frontend db server. #}
-{% set db_host = groups['postgresql_dbs'][0] %}
+{% if api_alternate_db_host %}
+{%     set db_host = api_alternate_db_host %}
+{% else %}
+{%     set db_host = groups['postgresql_dbs'][0] %}
+{% endif %}
 
 {# The "test" environment is not used yet. #}
 test:

--- a/ansible/roles/frontend/defaults/main.yml
+++ b/ansible/roles/frontend/defaults/main.yml
@@ -6,4 +6,5 @@ frontend_unicorn_worker_processes: 2
 frontend_use_local_source: false
 frontend_branch_or_tag: master
 frontend_s3_bucket: changeme
+frontend_alternate_db_host: false
 bookshelf_max_pages: 100

--- a/ansible/roles/frontend/templates/database.yml.j2
+++ b/ansible/roles/frontend/templates/database.yml.j2
@@ -1,6 +1,9 @@
 
-{# Assume there's just one frontend db server. #}
-{% set db_host = groups['postgresql_dbs'][0] %}
+{% if frontend_alternate_db_host %}
+{%     set db_host = frontend_alternate_db_host %}
+{% else %}
+{%     set db_host = groups['postgresql_dbs'][0] %}
+{% endif %}
 
 {# The "test" environment is not used yet. #}
 test:

--- a/ansible/roles/ingestion_app/defaults/main.yml
+++ b/ansible/roles/ingestion_app/defaults/main.yml
@@ -5,6 +5,7 @@ ingestion_use_local_source: false
 heidrun_branch_or_tag: develop
 heidrun_mappings_branch_or_tag: master
 ingestion_app_rails_env: development
+ingestion_app_alternate_db_host: false
 
 ingestion_secret_key_base: 227577a6f5b650eee5e30d2519872b0163a4b3112449ff4876cf9b5d7bf3edae86935d7dea2b59466ea435617116f9c2dafa6fa19e078e05017693a2a330cebc
 

--- a/ansible/roles/ingestion_app/templates/database.yml.j2
+++ b/ansible/roles/ingestion_app/templates/database.yml.j2
@@ -1,7 +1,10 @@
-{# Assume there's just one db server. #}
-{% set db_host = groups['postgresql_dbs'][0] %}
 
-{# The "test" environment is not used yet. #}
+{% if ingestion_app_alternate_db_host %}
+{%     set db_host = ingestion_app_alternate_db_host %}
+{% else %}
+{%     set db_host = groups['postgresql_dbs'][0] %}
+{% endif %}
+
 test:
   adapter: postgresql
   encoding: unicode
@@ -15,7 +18,6 @@ development:
   adapter: postgresql
   encoding: unicode
   host: {{ db_host }}
-  hostname: localhost
   database: ingestion
   username: {{ postgresql_user['name'] }}
   password: {{ postgresql_user['password'] }}

--- a/ansible/roles/pss/defaults/main.yml
+++ b/ansible/roles/pss/defaults/main.yml
@@ -25,3 +25,4 @@ pss_zencoder_notification_user: OVERRIDE-THIS
 pss_zencoder_notification_pass: OVERRIDE-THIS
 pss_zencoder_s3_credentials_name: false
 pss_contact_email: email@example.com
+pss_alternate_db_host: false

--- a/ansible/roles/pss/templates/database.yml.j2
+++ b/ansible/roles/pss/templates/database.yml.j2
@@ -1,6 +1,8 @@
-
-{# Assume there's just one frontend db server. #}
-{% set db_host = groups['postgresql_dbs'][0] %}
+{% if pss_alternate_db_host %}
+{%     set db_host = pss_alternate_db_host %}
+{% else %}
+{%     set db_host = groups['postgresql_dbs'][0] %}
+{% endif %}
 
 test:
   adapter: postgresql


### PR DESCRIPTION
For various roles, add variables that allow for database hosts that exist outside of the inventory.  A good example is an Amazon RDS database instance that's not used in development.

The variables default to false so that normally the PostgreSQL database host is used.

To verify the behavior, you should be able to run `ansible-playbook` with `-C -D` and observe no changes to the `database.yml` config files, except for the removal of one line that I sneaked in there to remove a bogus property `hostname` from the `ingestion_app` file.

If you override something like `api_alternate_db_host` you should be able to see a change being proposed to the `database.yml` file with `-C -D`.
