### PR TITLE
Set default port for PSS application

### DIFF
--- a/ansible/group_vars/all.dist
+++ b/ansible/group_vars/all.dist
@@ -65,6 +65,8 @@ exhibitions_app_port: 8000
 wordpress_app_port: 8001
 frontend_app_port: 8002
 ingestion_app_port: 8004
+# port 8005 is used by Tomcat
+pss_app_port: 8006
 
 nginx_real_ip_from_addrs:
     - 192.168.50.0/24


### PR DESCRIPTION
A new from-scratch deployment fails if you're just copying `group_vars/all.dist` to `group_vars/all`. There is no default value for the `pss_app_port` variable.