### PR TITLE
Fix VM memory overallocation

### DIFF
--- a/Vagrantfile.ingestion2
+++ b/Vagrantfile.ingestion2
@@ -21,7 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     dev1.vm.box = 'hashicorp/precise64'  # Ubuntu 12.04 LTS
     dev1.vm.network :private_network, ip: '192.168.50.7'
     dev1.vm.provider :virtualbox do |vb|
-      vb.memory = 2048
+      vb.memory = 2048  # 2 GiB
     end
     #
     # *** EDIT THESE FOR LOCAL DEVELOPMENT ***
@@ -37,7 +37,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     dev2.vm.box = 'ubuntu/trusty64'  # Ubuntu 14.04 LTS
     dev2.vm.network :private_network, ip: '192.168.50.8'
     dev2.vm.provider :virtualbox do |vb|
-      vb.memory = 2048
+      vb.memory = 3072  # 3 GiB
     end
     # *** EDIT THESE FOR LOCAL DEVELOPMENT ***
     # As above, change the path to the local diretory.

--- a/ansible/ingestion
+++ b/ansible/ingestion
@@ -40,7 +40,7 @@ dev2
 [worker]
 dev2
 [worker:vars]
-worker_queues=[{'name': 'harvest', 'num_workers': 1}, {'name': 'mapping', 'num_workers': 1}, {'name': 'enrichment', 'num_workers': 1}, {'name': 'indexing', 'num_workers': 1}]
+worker_queues=[{'name': '*', 'num_workers': 2}]
 
 [development_ingestion2]
 dev1

--- a/ansible/roles/ingestion_app/defaults/main.yml
+++ b/ansible/roles/ingestion_app/defaults/main.yml
@@ -9,4 +9,4 @@ ingestion_app_alternate_db_host: false
 
 ingestion_secret_key_base: 227577a6f5b650eee5e30d2519872b0163a4b3112449ff4876cf9b5d7bf3edae86935d7dea2b59466ea435617116f9c2dafa6fa19e078e05017693a2a330cebc
 
-ingestion_app_unicorn_worker_processes: 2
+ingestion_app_unicorn_worker_processes: 1


### PR DESCRIPTION
Reduce the amount of memory taken by Ruby processes in the 'ingestion' inventory for Ingestion 2 by reducing the number of processes.

Also give a little more memory to the 'dev2' VM in the Vagrantfile.

The worker processes could be dropped to just one, but I figure that it could be useful in development to make sure that the system works with concurrently-running processes.
