### PR TITLE
Make twofishes start with system locale

### DIFF
--- a/ansible/roles/geocoder/templates/etc_init.d_twofishes.j2
+++ b/ansible/roles/geocoder/templates/etc_init.d_twofishes.j2
@@ -14,6 +14,9 @@ set -e
 
 . /lib/lsb/init-functions
 
+# Make sure that Twofishes is started with the system locale.
+. /etc/default/locale
+export LANG
 
 JAR={{ twofishes_jar_name }}
 INDEX_DIR={{ index_dir_name_result.stdout_lines.0 }}


### PR DESCRIPTION
Fix the init script to export the LANG locale environment variable, which fixes an error with the startup of twofishes, where it is not happy trying to read its database with the ASCII encoding.  It should try to use UTF8.

The `twofishes` init script was failing to start `twofishes` upon reboot.
