### PR TITLE
Disable Spring wherever we use Ruby

### DIFF
--- a/ansible/files/install_ruby_tools.sh
+++ b/ansible/files/install_ruby_tools.sh
@@ -34,3 +34,6 @@ else
 fi
 rbenv rehash
 
+if (! `grep -q DISABLE_SPRING ~/.bashrc`); then
+    echo "export DISABLE_SPRING=1" >> ~/.bashrc
+fi


### PR DESCRIPTION
Add `DISABLE_SPRING=1` to the `dpla` user's `.bashrc` wherever we set up Ruby.  We've always had problems running the Rails console whenever Spring has been running.  This is mostly a development issue.

I chose `install_ruby_tools.sh` because that's where other Ruby-related things are already set up, like `rbenv` and `bundler`.