### PR TITLE
Add new Bulk Download file script

### DIFF
--- a/ansible/central_all.yml
+++ b/ansible/central_all.yml
@@ -21,6 +21,7 @@
     - munin_master
     - common_web
     - monitoring_web
+    - { role: exporter, tags: ['exporter'] }
   vars:
     production_munin_master: true
     level: production

--- a/ansible/roles/aws_postfix/templates/aliases.j2
+++ b/ansible/roles/aws_postfix/templates/aliases.j2
@@ -4,4 +4,5 @@ www-data:       {{ admin_notifications_from }}
 munin:          {{ admin_notifications_from }}
 postgres:       {{ admin_notifications_from }}
 dpla:           {{ admin_notifications_from }}
+exporter:       {{ admin_notifications_from }}
 root:           {{ admin_notifications_from }}

--- a/ansible/roles/exporter/defaults/main.yml
+++ b/ansible/roles/exporter/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+
+exporter_access_key: changeme
+exporter_secret_key: changeme
+exporter_bucket: changeme
+exporter_cron_time: "30 0 1 * *"
+exporter_output_dir: /var/tmp
+exporter_s3_bucket: changeme

--- a/ansible/roles/exporter/files/export-provider.sh
+++ b/ansible/roles/exporter/files/export-provider.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+## export-provider.sh
+#
+#  Export the DPLA search index to files, per-provider or for all items, and
+#  upload these files to an Amazon S3 bucket.
+#
+#  These files are known as Bulk Download files:
+#  http://dp.la/info/developers/download/
+
+SCRIPT=`basename ${BASH_SOURCE[0]}`
+
+which aws > /dev/null && which elasticdump > /dev/null && which jq > /dev/null
+if [ $? -ne 0 ]; then
+    >&2 echo "\`aws', \`elasticdump', and \`jq' must be available in \$PATH."
+    exit 1
+fi
+
+# Figure out `sed' options for extended regexes
+sed -r 2>/dev/null
+if [ $? -eq 0 ]; then
+    sed_opts="-r"  # GNU
+else
+    sed_opts="-E"  # OS X
+fi
+
+
+usage() {
+    cat <<END
+
+Usage:  $SCRIPT -u <url> -o <directory> -s <s3 bucket> -p <provider>...
+
+    -u    Elasticsearch URL (including index)
+    -o    Output directory
+    -s    S3 destination bucket
+    -h    Help (this message)
+    -p    The name of one provider, or "all" for all of them, or "each"
+          for each one (queried from the search index).  "all" and
+          "each" can be used together.  Multiple providers may be specified.
+          The provider name corresponds to provider.@id in our schema.
+
+END
+}
+
+# Generate the Elasticsearch Query API syntax that is used to select which
+# records to export
+searchbody() {
+    if [ "$@" == "all" ]; then
+        echo '{"query": {"match_all": {}}}'
+    else
+        cat <<END
+{
+    "query": {
+        "query_string": {
+            "default_field": "provider.@id",
+            "query": "*$1"
+        }
+    }
+}
+END
+    fi
+}
+
+# Generate the Elasticsearch Query API syntax that is used to get a list of
+# all providers by provider.@id
+providers_list_search_body() {
+    cat <<END
+{
+    "query": {
+        "match_all": {}
+    },
+    "facets": {
+        "providers": {
+            "terms": {
+                "field": "provider.@id",
+                "size": 500
+            }
+        }
+    },
+    "size": 0
+}
+END
+}
+
+
+providers_list_response() {
+    curl -s -X POST "$ES_URL/_search" \
+        -d "`providers_list_search_body`"
+    if [ $? -ne 0 ]; then
+        >&2 echo "Could not query provider listing"
+        exit 1
+    fi
+}
+
+# Given JSON produced by `providers_list_search_body`, return a list of tokens
+# that represent the substrings at the end of provider.@id.
+# For example, "nypl" for "http://dp.la/api/contributor/nypl"
+providers_list() {
+    json=`providers_list_response`
+    echo $json | jq '.facets.providers.terms[].term' \
+        | sed $sed_opts 's/^.*\/([^\/]+)"$/\1/'
+}
+
+# Return basename of the output file, which is gzipped JSON
+outfile() {
+    base=`echo $1 | sed $sed_opts 's/[^A-Za-z]+/_/g;'`
+    echo ${base}.json.gz
+}
+
+# Export a provider (or "all" providers) and upload the file
+export_and_upload() {
+    sbody=`searchbody "$@"`
+    ofile=`outfile "$@"`
+    output="${OUTDIR}/${ofile}"
+    elasticdump --searchBody "$sbody" \
+        --input=$ES_URL --output=$ | gzip > $output  \
+        || exit 1
+    bn=`basename $output`
+    dir=`date +"%Y/%m"`
+    aws s3 cp --quiet  \
+        --content-type "application/gzip" --content-encoding "identity" \
+        $output s3://$BUCKET/$dir/$bn \
+        || exit 1
+    rm $output || exit 1
+}
+
+declare -a providers
+provider_idx=0
+# Get options
+while getopts :f:u:o:s:p:h flag; do
+    case $flag in
+        u)
+            ES_URL=$OPTARG
+            ;;
+        o)
+            OUTDIR=$OPTARG
+            ;;
+        s)
+            BUCKET=$OPTARG
+            ;;
+        p)
+            providers[$provider_idx]="$OPTARG"
+            provider_idx=$(( $provider_idx + 1 ))
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            usage
+            exit 1
+            ;;
+    esac
+    i=$(( $i + 1 ))
+done
+shift $((OPTIND-1))  # Move to next argument
+
+# Check various arguments
+#
+if [ "x$ES_URL" == "x" ]; then
+    >&2 echo "Unknown Elasticsearch URL"
+    usage
+    exit 1
+fi
+
+if [ "x$OUTDIR" == "x" ]; then
+    >&2 echo "Unknown output directory"
+    usage
+    exit 1
+fi
+OUTDIR=`echo $OUTDIR | sed 's/\/$//'`
+
+if [ "x$BUCKET" == "x" ]; then
+    >&2 echo "Unknown S3 bucket"
+    usage
+    exit 1
+fi
+
+## Export each provider
+#
+for (( j=0; $j < $provider_idx ; j=$(( j + 1 )) )); do
+    if [ "${providers[$j]}" == "each" ]; then
+        for provider in `providers_list`; do
+            export_and_upload "$provider"
+        done
+    else
+        export_and_upload "${providers[$j]}"
+    fi
+done
+
+exit 0

--- a/ansible/roles/exporter/tasks/main.yml
+++ b/ansible/roles/exporter/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+
+- name: Ensure that privsep account exists for exports
+  user: >-
+      name=exporter comment="Privilege separtion user for export files"
+      home=/home/exporter shell=/bin/bash state=present
+
+- name: Ensure that AWS CLI is installed
+  pip: name=awscli state=present
+
+- name: Ensure state of AWS CLI configuration directory
+  file: >-
+    path=/home/exporter/.aws state=directory owner=exporter group=exporter
+    mode=0700
+
+- name: Ensure state of AWS CLI credentials file
+  template: >-
+    src=aws_credentials.j2 dest=/home/exporter/.aws/credentials
+    owner=exporter group=exporter mode=0600
+
+- name: Ensure state of AWS CLI config file
+  template: >-
+    src=aws_config.j2 dest=/home/exporter/.aws/config
+    owner=exporter group=exporter mode=0600
+
+- name: Ensure that node and npm are installed for elasticdump Node package
+  apt: >-
+    pkg="{{ item }}" state=present
+  with_items:
+    - nodejs
+    - npm
+    - jq
+
+# See https://lists.debian.org/debian-devel-announce/2012/07/msg00002.html
+# See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=614907
+- name: Symlink node binary
+  file: src=/usr/bin/nodejs dest=/usr/bin/node state=link
+
+- name: Ensure that elasticdump is installed
+  npm: name=elasticdump version=0.8.1 global=yes
+
+- name: Ensure state of export script
+  copy: >-
+    src=export-provider.sh dest=/usr/local/bin/export-provider.sh
+    owner=root group=root mode=0755
+
+- name: Ensure state of crontab file for exports
+  template: >-
+    src=etc_cron.d_export-providers.j2 dest=/etc/cron.d/export-providers
+    owner=root group=root mode=0644
+

--- a/ansible/roles/exporter/templates/aws_config.j2
+++ b/ansible/roles/exporter/templates/aws_config.j2
@@ -1,0 +1,3 @@
+[default]
+region={{ aws_region }}
+output=json

--- a/ansible/roles/exporter/templates/aws_credentials.j2
+++ b/ansible/roles/exporter/templates/aws_credentials.j2
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id={{ exporter_access_key }}
+aws_secret_access_key={{ exporter_secret_key }}

--- a/ansible/roles/exporter/templates/etc_cron.d_export-providers.j2
+++ b/ansible/roles/exporter/templates/etc_cron.d_export-providers.j2
@@ -1,0 +1,6 @@
+ES_URL=http://{{ es_cluster_loadbal }}:9200/dpla_alias
+OUTDIR={{ exporter_output_dir }}
+BUCKET={{ exporter_bucket }}
+PATH=/usr/local/bin:/usr/bin:/bin
+
+{{ exporter_cron_time }} exporter /usr/local/bin/export-provider.sh -p all -p each


### PR DESCRIPTION
This script generates and uploads Bulk Download files straight from the Elasticsearch index, and supercedes the file-generation functionality of the legacy [ingestion](https://github.com/dpla/ingestion) project.

This change includes the automation necessary to have it run automatically on the `central` server, if that exists.

The script is designed to be useful either on cron or as a tool for exporting individual files on command. As such, it can be run locally or on the server.
