### PR TITLE
Fix undefined variable, elasticsearch reboot

### DIFF
--- a/ansible/playbooks/reboot_elasticsearch.yml
+++ b/ansible/playbooks/reboot_elasticsearch.yml
@@ -1,10 +1,10 @@
 ---
 
-- hosts: 127.0.0.1
-  connection: local
-  sudo: false
+- hosts:
+    - elasticsearch[0]
   tasks:
     - name: Turn off shard replica allocation
+      sudo: false
       local_action: >-
           script ../files/set-allocation.sh off "{{ es_cluster_loadbal }}"
 
@@ -52,10 +52,10 @@
         aws_region: "{{ aws_region }}"
         state: present
 
-- hosts: 127.0.0.1
-  connection: local
-  sudo: false
+- hosts:
+    - elasticsearch[0]
   tasks:
     - name: Turn shard replica allocation back on
+      sudo: false
       local_action: >-
           script ../files/set-allocation.sh on "{{ es_cluster_loadbal }}"


### PR DESCRIPTION
Change the invocation of a local action to run the set-allocation.sh script in order for the es_cluster_loadbal variable to be inherited from the relevant group_vars file.

This fixes an error about that variable being undefined. This issue was introduced back when the variables were rearranged.
