### PR TITLE
Add Primary Source Sets mail settings

### DIFF
--- a/ansible/roles/pss/defaults/main.yml
+++ b/ansible/roles/pss/defaults/main.yml
@@ -28,3 +28,6 @@ pss_contact_email: email@example.com
 pss_alternate_db_host: false
 pss_include_branding: false
 pss_display_tags_on_public_ui: false
+# Default mail delivery is :file, for development.  Mail is stored in
+# /srv/www/pss/tmp/mails.
+pss_delivery_method: file

--- a/ansible/roles/pss/templates/settings.local.yml.j2
+++ b/ansible/roles/pss/templates/settings.local.yml.j2
@@ -37,3 +37,7 @@ googleanalytics:
 contact_email: {{ pss_contact_email }}
 
 display_tags_on_public_ui: {{ pss_display_tags_on_public_ui }}
+
+
+action_mailer:
+  delivery_method: {{ pss_delivery_method }}


### PR DESCRIPTION
See https://github.com/dpla/primary-source-sets/pull/104

There are some new Primary Source Sets application mail settings that need to be configured.

See http://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration and http://api.rubyonrails.org/classes/ActionMailer/Base.html

We set a default of `file` for development, because we don't run a MTA on the development VMs.  Staging and production environments can override this with `sendmail` so that `/usr/sbin/sendmail` is used.
