### PR TITLE
Fix sqlite3 dependency, frontend app

### DIFF
--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -36,7 +36,7 @@ echo "using rbenv version $USE_VERSION" >> $LOGFILE
 echo "installing bundle ..." >> $LOGFILE
 
 rm -f Gemfile.lock
-bundle install >> $LOGFILE 2>&1
+bundle install --without test >> $LOGFILE 2>&1
 if [ $? -ne 0 ]; then
     exit 1
 fi


### PR DESCRIPTION
Add these Ubuntu packages, because we've recently added the `sqlite3` gem to the `frontend` app for tests, and bundler wants to install it regardless of the environment.