### PR TITLE
remove obsolete pss tag setting

### DIFF
--- a/ansible/roles/pss/defaults/main.yml
+++ b/ansible/roles/pss/defaults/main.yml
@@ -27,7 +27,6 @@ pss_zencoder_s3_credentials_name: false
 pss_contact_email: email@example.com
 pss_alternate_db_host: false
 pss_include_branding: false
-pss_display_tags_on_public_ui: false
 # Default mail delivery is :file, for development.  Mail is stored in
 # /srv/www/pss/tmp/mails.
 pss_delivery_method: file

--- a/ansible/roles/pss/templates/settings.local.yml.j2
+++ b/ansible/roles/pss/templates/settings.local.yml.j2
@@ -36,8 +36,5 @@ googleanalytics:
 
 contact_email: {{ pss_contact_email }}
 
-display_tags_on_public_ui: {{ pss_display_tags_on_public_ui }}
-
-
 action_mailer:
   delivery_method: {{ pss_delivery_method }}


### PR DESCRIPTION
This removes an obsolete setting for the `primary source sets` application.

This addresses [ticket #8246](https://issues.dp.la/issues/8246).

This relates to [aws PR#35](https://github.com/dpla/aws/pull/35/files) and [pss PR#110](https://github.com/dpla/primary-source-sets/pull/110).