### PR TITLE
Fix pkill task to stop old delayed_job process

### DIFF
--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -50,7 +50,12 @@
 # Clean up delayed_job init scripts and processes that used to be created in
 # earlier versions of this file
 - name: Stop obsolete delayed_job if it is running
-  command: pkill -9 -f delayed_job
+  shell: pkill -9 -f delayed_job
+  register: pkill_result
+  # The `shell' module returns -9 if the process not running, and it is OK if it
+  # was not.
+  failed_when: "pkill_result.rc != 0 and pkill_result.rc != -9"
+  changed_when: pkill_result.rc == 0
   tags:
     - web
     - initscripts


### PR DESCRIPTION
`pkill -f` actually returns an error status if the process did not exist, although it prints "Killed" to the terminal (not stdout or stderr -- I'm not sure which file it goes to).

Interestingly, plain `pkill` (without -f) does _not_ print "Killed" if the process did not exist, and it exits with 1.

The status that `pkill -f` returns if the process did not exist is 137, if a SIGKILL (-9) fails.  See http://tldp.org/LDP/abs/html/exitcodes.html 

The ansible `command` module was giving the return code as 1 in this case, instead of 137. The `shell` module, on the other hand, returns -9, which is not what we'd expect (137) but is better than 1, which is
indistinguishable from other kinds of failures.