### PR TITLE
Allow alternate repos for ingestion

### DIFF
--- a/ansible/roles/ingestion_app/defaults/main.yml
+++ b/ansible/roles/ingestion_app/defaults/main.yml
@@ -3,7 +3,9 @@
 ingestion_rbenv_version: 2.1.3
 ingestion_use_local_source: false
 heidrun_branch_or_tag: develop
+heidrun_repo: dpla/heidrun
 heidrun_mappings_branch_or_tag: master
+heidrun_mappings_repo: dpla/heidrun-mappings
 ingestion_app_rails_env: development
 ingestion_app_alternate_db_host: false
 

--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -4,7 +4,7 @@
 
 - name: Ensure that Solr schema file is current (network)
   get_url: >-
-    url="https://raw.githubusercontent.com/dpla/heidrun/{{ heidrun_branch_or_tag }}/solr_conf/schema.xml"
+    url="https://raw.githubusercontent.com/{{ heidrun_repo }}/{{ heidrun_branch_or_tag }}/solr_conf/schema.xml"
     dest=/opt/solr/dpla/solr/collection1/conf/schema.xml force=yes
     mode=0644 owner=root group=root
   delegate_to: "{{ item }}"
@@ -30,7 +30,7 @@
 
 - name: Ensure the state of solrconfig.xml (network)
   get_url: >-
-    url="https://raw.githubusercontent.com/dpla/heidrun/{{ heidrun_branch_or_tag }}/solr_conf/solrconfig.xml"
+    url="https://raw.githubusercontent.com/{{ heidrun_repo }}/{{ heidrun_branch_or_tag }}/solr_conf/solrconfig.xml"
     dest=/opt/solr/dpla/solr/collection1/conf/solrconfig.xml force=yes
     mode=0644 owner=root group=root
   delegate_to: "{{ item }}"
@@ -85,10 +85,12 @@
 - file: path=/home/dpla/heidrun-mappings state=absent
 
 # Copy files to build, network installation
+#   (See vars/main.yml for `heidrun_working_copy` and
+#   `heidrun_mappings_working_copy`)
 - name: Check out ingestion app from its repository (not using local source)
   git: >-
-      repo=https://github.com/dpla/heidrun.git
-      dest=/home/dpla/heidrun-git
+      repo=https://github.com/{{ heidrun_repo }}.git
+      dest=/home/dpla/{{ heidrun_working_copy }}
       version={{ heidrun_branch_or_tag }}
       force=true
   sudo_user: dpla
@@ -96,18 +98,25 @@
 
 - name: Check out mappings from their repository (not using local source)
   git: >-
-      repo=https://github.com/dpla/heidrun-mappings.git
-      dest=/home/dpla/heidrun-mappings-git
+      repo=https://github.com/{{ heidrun_mappings_repo }}.git
+      dest=/home/dpla/{{ heidrun_mappings_working_copy }}
       version={{ heidrun_mappings_branch_or_tag }}
       force=true
   sudo_user: dpla
   when: not ingestion_use_local_source
 
-# Symlink to the build directories, to allow local and git builds to coexist neatly
+# Symlink to the build directories, to allow local and git builds to coexist
+# neatly
 # 1. For a git deployment ...
-- file: src=/home/dpla/heidrun-git dest=/home/dpla/heidrun state=link
+- file: >-
+    src=/home/dpla/{{ heidrun_working_copy }}
+    dest=/home/dpla/heidrun
+    state=link
   when: not ingestion_use_local_source
-- file: src=/home/dpla/heidrun-mappings-git dest=/home/dpla/heidrun-mappings state=link
+- file: >-
+    src=/home/dpla/{{ heidrun_mappings_working_copy }}
+    dest=/home/dpla/heidrun-mappings
+    state=link
   when: not ingestion_use_local_source
 
 # Copy files to build, local filesystem installation

--- a/ansible/roles/ingestion_app/vars/main.yml
+++ b/ansible/roles/ingestion_app/vars/main.yml
@@ -5,3 +5,8 @@
 # application code.  It skips things like database migration and updating the
 # bundle.
 fast_deployment: false
+
+heidrun_working_copy: >-
+    {{ heidrun_repo | replace('/', '_') }}_git
+heidrun_mappings_working_copy: >-
+    "{{ heidrun_mappings_repo | replace('/', '_') }}_git"


### PR DESCRIPTION
Parameterize the GitHub repositories that are used for `heidrun` and `heidrun_mappings`.  This allows us to do deployments into our test or development systems from forked repositories.
