### PR TITLE
Add missing inventory groups to reboot play

### DIFF
--- a/ansible/playbooks/reboot.yml
+++ b/ansible/playbooks/reboot.yml
@@ -13,6 +13,11 @@
   hosts:
     - ingestion
     - cms
+    - ingestion_app
+    - worker
+    - solr
+    - marmotta
+    - geocoder
   sudo: yes
   tasks:
     - name: Reboot


### PR DESCRIPTION
See https://issues.dp.la/issues/7834

Add missing inventory groups to the first play in `reboot.yml`.
