### PR TITLE
Add DPLA API key to primary-source-sets

### DIFF
--- a/ansible/roles/pss/templates/settings.local.yml.j2
+++ b/ansible/roles/pss/templates/settings.local.yml.j2
@@ -12,6 +12,9 @@ wordpress:
 exhibitions:
   url: {{ pss_exhibitions_url }}
 
+api:
+  key: {{ api_key }}
+
 app_scheme: {{ pss_app_scheme }}
 app_host: {{ pss_app_host }}
 


### PR DESCRIPTION
See https://github.com/dpla/primary-source-sets/pull/126

This is necessary for the change in that PR to be deployed, but it's harmless for the config file to be modified without it.
