### PR TITLE
Add pss_api_key variable

### DIFF
--- a/ansible/roles/pss/defaults/main.yml
+++ b/ansible/roles/pss/defaults/main.yml
@@ -30,3 +30,4 @@ pss_include_branding: false
 # Default mail delivery is :file, for development.  Mail is stored in
 # /srv/www/pss/tmp/mails.
 pss_delivery_method: file
+pss_api_key: aa11d0958e93bb25e457a726dc10a40f

--- a/ansible/roles/pss/templates/settings.local.yml.j2
+++ b/ansible/roles/pss/templates/settings.local.yml.j2
@@ -13,7 +13,7 @@ exhibitions:
   url: {{ pss_exhibitions_url }}
 
 api:
-  key: {{ api_key }}
+  key: {{ pss_api_key }}
 
 app_scheme: {{ pss_app_scheme }}
 app_host: {{ pss_app_host }}


### PR DESCRIPTION
Add variable dedicated to Primary Source Sets' own DPLA API key. The application could want to have its own key, instead of using the same one as the frontend.

The default key is the same as `api_key` and is simply one of the dummy keys that's created by the `platform` app and used in development.