### PR TITLE
Block bad bot using Pcore-HTTP/v0.18.1, which ignores robots.txt

### DIFF
--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -53,6 +53,7 @@ map $http_user_agent $bad_bot{
     "-"         1;
     "0"         1;
     "Mozilla/5.0 (compatible; SiteBot/0.1; +http://www.sitebot.org/robot/)"     1;
+    "Pcore-HTTP/v0.18.1"    1;
 }
 
 map $http_content_type $do_not_cache {


### PR DESCRIPTION
This addresses the distributed crawls we're seeing in production that are hammering the search cluster, and that are ignoring robots.txt (which specifies that `/search`, `/timeline`, `/map`, and `/bookshelf` shouldn't be crawled). 