### PR TITLE
Add SSL capability and thumbnail proxy

### DIFF
--- a/ansible/development
+++ b/ansible/development
@@ -41,6 +41,9 @@ webapps
 [elasticsearch:children]
 dbnodes
 
+[thumbp:children]
+webapps
+
 [development]
 loadbal
 dbnode1

--- a/ansible/group_vars/all.dist
+++ b/ansible/group_vars/all.dist
@@ -59,9 +59,12 @@ api_hostname: local.dp.la
 sitemap_host: sitemaps.example.tld
 marmotta_domain: ldp.local.dp.la
 
-# HTTP ports for various applications
+# HTTP ports/configuration for various applications
+#
 # api_port is the port the *loadbalancer* answers on for API requests
 api_port: 8080
+# api_default_protocol should not have trailing '://'
+api_default_protocol: http
 # api_app_port is the port the *backend app server* runs on
 api_app_port: 8003
 exhibitions_app_port: 8000

--- a/ansible/group_vars/all.dist
+++ b/ansible/group_vars/all.dist
@@ -70,6 +70,7 @@ frontend_app_port: 8002
 ingestion_app_port: 8004
 # port 8005 is used by Tomcat
 pss_app_port: 8006
+thumbp_port: 8007
 
 nginx_real_ip_from_addrs:
     - 192.168.50.0/24

--- a/ansible/playbooks/dev_webapps.yml
+++ b/ansible/playbooks/dev_webapps.yml
@@ -41,6 +41,7 @@
   sudo: yes
   roles:
     - frontend
+    - { role: thumbp, tags: ['thumbp']}
   vars:
     level: development
     do_deployment: true

--- a/ansible/playbooks/thumbp.yml
+++ b/ansible/playbooks/thumbp.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Gather inventory facts in case playbook is run standalone
+  hosts: all
+
+- name: Thumbnail proxy
+  hosts: thumbp
+  serial: 1
+  become: yes
+  roles:
+    - thumbp

--- a/ansible/playbooks/thumbp_development.yml
+++ b/ansible/playbooks/thumbp_development.yml
@@ -1,0 +1,3 @@
+---
+
+- include: thumbp.yml level=development

--- a/ansible/playbooks/thumbp_production.yml
+++ b/ansible/playbooks/thumbp_production.yml
@@ -1,0 +1,3 @@
+---
+
+- include: thumbp.yml level=production

--- a/ansible/playbooks/thumbp_staging.yml
+++ b/ansible/playbooks/thumbp_staging.yml
@@ -1,0 +1,3 @@
+---
+
+- include: thumbp.yml level=staging

--- a/ansible/roles/frontend/templates/etc_nginx_sites-available_frontend.j2
+++ b/ansible/roles/frontend/templates/etc_nginx_sites-available_frontend.j2
@@ -25,7 +25,6 @@ server {
 
     location @frontend_app_server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto http;
         proxy_set_header Host $http_host;
         proxy_redirect off;
         proxy_pass http://frontend_app_server;

--- a/ansible/roles/frontend/templates/settings.local.yml.j2
+++ b/ansible/roles/frontend/templates/settings.local.yml.j2
@@ -8,7 +8,7 @@ notifications:
 # DPLA API URL and credentials
 api:
   # Without trailing slash, please
-  url: http://{{ api_hostname }}:{{ api_port }}/v2
+  url: https://{{ api_hostname }}:{{ api_port }}/v2
   # API key, will be added to all API requests as &api_key=
   key: {{ api_key }}
 exhibitions:
@@ -20,7 +20,7 @@ exhibitions:
     default_index: omeka
 wordpress:
   # Wordpress site for building links to pages served by WP
-  site: http://{{ frontend_hostname }}/info
+  site: //{{ frontend_hostname }}/info
 # Google Analytics account
 googleanalytics:
   tracker: {{ google_analytics_property_id }}
@@ -44,8 +44,8 @@ widgets:
   twitter_widget_id: {{ twitter_widget_id }}
   # URL of wordpress site.
   # NOTE: JSON API plugin is required to able read Wordpress feed as JSONP requests
-  wordpress_json_api: http://{{ frontend_hostname }}/info
-  wordpress_view_all_link: http://{{ frontend_hostname }}/info/news/
+  wordpress_json_api: //{{ frontend_hostname }}/info
+  wordpress_view_all_link: //{{ frontend_hostname }}/info/news/
   # Urls for social icons
   social_icons:
     facebook: https://www.facebook.com/{{ facebook_account_name }}

--- a/ansible/roles/frontend/templates/settings.local.yml.j2
+++ b/ansible/roles/frontend/templates/settings.local.yml.j2
@@ -8,7 +8,7 @@ notifications:
 # DPLA API URL and credentials
 api:
   # Without trailing slash, please
-  url: https://{{ api_hostname }}:{{ api_port }}/v2
+  url: {{ api_default_protocol }}://{{ api_hostname }}:{{ api_port }}/v2
   # API key, will be added to all API requests as &api_key=
   key: {{ api_key }}
 exhibitions:

--- a/ansible/roles/omeka/templates/application_config_config.ini.j2
+++ b/ansible/roles/omeka/templates/application_config_config.ini.j2
@@ -242,8 +242,8 @@ mail.transport.type = "Sendmail"
 ; Set the maximum file upload size.
 ; default: 10M
 ;
-; Uncomment the following line to set the maximum file upload size. This 
-; configuration will not exceed the maximum beyond what is set in the 
+; Uncomment the following line to set the maximum file upload size. This
+; configuration will not exceed the maximum beyond what is set in the
 ; 'post_max_size' or 'upload_max_filesize' core php.ini directives.
 ;
 upload.maxFileSize = "50M"

--- a/ansible/roles/site_proxy/defaults/main.yml
+++ b/ansible/roles/site_proxy/defaults/main.yml
@@ -37,3 +37,8 @@ siteproxy_nginx_limit_conn_log_level: notice
 # are simply delayed (per the rate and burst parameters), they will be logged at
 # one level lower.
 siteproxy_nginx_limit_req_log_level: notice
+
+# Maximum disk space used by the NGINX cache. Our default is 6 Gb.
+siteproxy_nginx_cache_max_size: 6144m
+# Size of shared memory zone that is used for NGINX cache
+siteproxy_nginx_cache_shmem_size: 360m

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -1,6 +1,6 @@
 
 # proxy configs
-proxy_cache_path  /var/cache/nginx  levels=1:2   keys_zone=staticfilecache:360m  max_size=10000m;
+proxy_cache_path  /var/cache/nginx levels=1:2 keys_zone=staticfilecache:{{ siteproxy_nginx_cache_shmem_size }} max_size={{ siteproxy_nginx_cache_max_size }};
 proxy_temp_path /var/spool/nginx;
 proxy_cache_key       "$scheme://$host$request_uri";
 proxy_cache         staticfilecache;
@@ -120,6 +120,13 @@ upstream dpla_portal {
 {% endfor %}
 }
 
+# Thumbnail proxy servers
+upstream dpla_thumbp {
+{% for h in groups['thumbp'] %}
+    server {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}:{{ thumbp_port }} fail_timeout=120s; # {{ h }}
+{% endfor %}
+}
+
 # Old wiki
 upstream dpla_berkman {
   server 128.103.64.94:80 weight=1 fail_timeout=120s;
@@ -194,6 +201,16 @@ server {
 
         limit_req zone=bookshelfreq burst={{ siteproxy_nginx_default_req_burst }};
         limit_conn bookshelfconn {{ siteproxy_bookshelf_max_conn }};
+    }
+
+    location /thumb {
+        proxy_cache_valid 200 60m;
+        proxy_cache_valid 404 1h;
+        proxy_cache_valid 403 24h;
+        proxy_cache_use_stale error timeout http_500 http_503;
+        expires 1d;
+        add_header Cache-Control "public";
+        proxy_pass http://dpla_thumbp;
     }
 
     location ~ ^/api/(.*)$ {

--- a/ansible/roles/thumbp/defaults/main.yml
+++ b/ansible/roles/thumbp/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+thumbp_branch_or_tag: master

--- a/ansible/roles/thumbp/files/install_python.sh
+++ b/ansible/roles/thumbp/files/install_python.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+PY_VERSION=2.7.10
+export PYENV_ROOT=$HOME/.pyenv
+export PATH=$PYENV_ROOT/bin:$PATH
+eval "$(pyenv init -)"
+
+pyenv install -s $PY_VERSION
+
+pyenv global $PY_VERSION
+
+pip install --upgrade pip
+
+pip install virtualenv
+
+pyenv rehash
+
+if [ ! -d /opt/thumbp/bin ]; then
+    virtualenv /opt/thumbp
+fi
+
+if [ "`/opt/thumbp/bin/python -V`" != "Python $PY_VERSION" ]; then
+    rm -rf /opt/thumbp/*
+    virtualenv /opt/thumbp
+fi

--- a/ansible/roles/thumbp/handlers/main.yml
+++ b/ansible/roles/thumbp/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: restart thumbp
+  service: name=thumbp state=restarted

--- a/ansible/roles/thumbp/tasks/main.yml
+++ b/ansible/roles/thumbp/tasks/main.yml
@@ -1,0 +1,94 @@
+---
+
+- name: Ensure existence of the "thumbp" account
+  user: >-
+      name=thumbp comment="thumbp privsep user"
+      home=/home/thumbp shell=/bin/bash state=present
+  tags:
+    - users
+
+- name: Ensure that necessary packages are installed
+  apt:
+    pkg: "{{ item }}"
+    state: present
+  with_items:
+    - libffi-dev
+    - libreadline-dev
+    - libbz2-dev
+    - libsqlite3-dev
+    - libssl-dev
+
+- name: Ensure state of log directory
+  file: path=/var/log/thumbp state=directory owner=thumbp group=thumbp mode=0755
+
+- name: Ensure state of pid directory
+  file: path=/var/run/thumbp state=directory owner=thumbp group=thumbp mode=0755
+
+- name: Ensure state of virtualenv directory
+  file: path=/opt/thumbp state=directory owner=thumbp group=thumbp mode=0755
+
+- name: Make sure that pyenv is installed (directory and scripts)
+  sudo_user: thumbp
+  git: >-
+      repo=https://github.com/yyuu/pyenv.git
+      dest=/home/thumbp/.pyenv
+      version=master
+
+- name: Ensure that pyenv is configured (PYENV_ROOT)
+  sudo_user: thumbp
+  lineinfile:
+    dest: /home/thumbp/.bashrc
+    state: present
+    regexp: "PYENV_ROOT="
+    line: "export PYENV_ROOT=$HOME/.pyenv"
+
+- name: Ensure that pyenv is configured (PATH)
+  sudo_user: thumbp
+  lineinfile:
+    dest: /home/thumbp/.bashrc
+    state: present
+    insertafter: "PYENV_ROOT="
+    line: "export PATH=$PYENV_ROOT/bin:$PATH"
+
+- name: Ensure that pyenv is configured (pyenv init)
+  sudo_user: thumbp
+  lineinfile:
+    dest: /home/thumbp/.bashrc
+    state: present
+    regexp: "pyenv init"
+    insertafter: "export PATH"
+    line: >-
+        eval \"$(pyenv init -)\"
+
+- name: Stop thumbp if it is running in case of virtualenv change
+  service: name=thumbp state=stopped
+  ignore_errors: yes
+
+- name: Ensure that the correct Python is installed
+  sudo_user: thumbp
+  script: install_python.sh
+
+- name: Install thumbp
+  sudo_user: thumbp
+  pip:
+    name: "git+https://github.com/dpla/thumbp.git@{{ thumbp_branch_or_tag }}#egg=thumbp"
+    executable: /opt/thumbp/bin/pip
+    state: latest
+
+- name: Ensure state of init script
+  template: >-
+    src=etc_init.d_thumbp.j2 dest=/etc/init.d/thumbp
+    owner=root group=root mode=0755
+  notify: restart thumbp
+  tags:
+    - initscripts
+
+- name: Clear init script runlevels in case of a change
+  command: update-rc.d -f thumbp remove
+  tags:
+    - initscripts
+
+- name: Ensure init script run levels
+  command: update-rc.d thumbp defaults
+  tags:
+    - initscripts

--- a/ansible/roles/thumbp/templates/etc_init.d_thumbp.j2
+++ b/ansible/roles/thumbp/templates/etc_init.d_thumbp.j2
@@ -1,0 +1,75 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides: thumbp
+# Required-Start: $all
+# Required-Stop: $network $local_fs $syslog
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: Start/stop thumbp
+# Description: Start/stop thumbp
+### END INIT INFO
+
+set -u
+set -e
+
+. /lib/lsb/init-functions
+
+# Make sure that thumbp is started with the system locale.
+. /etc/default/locale
+export LANG
+
+export PYENV_ROOT=/home/thumbp/.pyenv
+export PATH=$PYENV_ROOT/bin:$PATH
+
+THUMBP_ROOT=/opt/thumbp
+SERVER_NAME=twistd
+EXECUTABLE=$THUMBP_ROOT/bin/$SERVER_NAME
+PYTHON=$THUMBP_ROOT/bin/python2.7
+PIDFILE=/var/run/thumbp/thumbp.pid
+LOGDIR=/var/log/thumbp
+USER=thumbp
+GROUP=thumbp
+IF={{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['address'] }}
+IFPORT="tcp:{{ thumbp_port }}:interface=$IF"
+export ES_BASE=http://{{ es_cluster_loadbal }}:9200/dpla_alias/item
+
+usage() {
+    echo >&2 "Usage: $0 <start|stop|restart|reload|status|usage>"
+}
+
+start() {
+    log_daemon_msg "Starting thumbp" "thumbp"
+    cd $LOGDIR
+    $EXECUTABLE -u $USER -g $GROUP --pidfile=$PIDFILE web \
+        --class=thumbp.thumbp.resource -l $LOGDIR/access_log -p $IFPORT
+}
+
+stop() {
+    log_daemon_msg "Stopping thumbp" "thumbp"
+    kill `cat $PIDFILE`
+    log_end_msg $?
+    rm -f $PIDFILE
+}
+
+case $1 in
+start)
+    start
+    ;;
+stop)
+    stop
+    ;;
+restart|reload)
+    stop && sleep 3 && start
+    ;;
+status)
+    status_of_proc -p $PIDFILE $PYTHON $SERVER_NAME && exit 0 || exit $?
+    ;;
+usage)
+    usage
+    exit 0
+    ;;
+*)
+    usage
+    exit 1
+    ;;
+esac

--- a/ansible/roles/wordpress/templates/wp-config.php.j2
+++ b/ansible/roles/wordpress/templates/wp-config.php.j2
@@ -1,7 +1,15 @@
 <?php
 
-define('WP_HOME', 'http://{{ frontend_hostname }}/info');
-define('WP_SITEURL', 'http://{{ frontend_hostname }}/info');
+define('WP_HOME', '//{{ frontend_hostname }}/info');
+define('WP_SITEURL', '//{{ frontend_hostname }}/info');
+
+define('FORCE_SSL_ADMIN', true);
+// in some setups HTTP_X_FORWARDED_PROTO might contain
+// a comma-separated list e.g. http,https
+// so check for https existence
+if (strpos($_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false)
+       $_SERVER['HTTPS']='on';
+
 
 /** The name of the database for WordPress */
 define('DB_NAME', 'dpla_wp');
@@ -77,8 +85,8 @@ define('WP_DEBUG_LOG', {{ debug_value }});
 define('WP_DEBUG_DISPLAY', {{ debug_value }});
 
 define('DPLA_API_KEY', '{{ api_key }}');
-define('DPLA_FRONTEND_URL', 'http://{{ frontend_hostname }}');
-define('DPLA_API_URL', 'http://{{ api_hostname }}/v2');
+define('DPLA_FRONTEND_URL', '//{{ frontend_hostname }}');
+define('DPLA_API_URL', 'https://{{ api_hostname }}/v2');
 
 
 /** Absolute path to the WordPress directory. */

--- a/ansible/roles/wordpress/templates/wp-config.php.j2
+++ b/ansible/roles/wordpress/templates/wp-config.php.j2
@@ -86,8 +86,7 @@ define('WP_DEBUG_DISPLAY', {{ debug_value }});
 
 define('DPLA_API_KEY', '{{ api_key }}');
 define('DPLA_FRONTEND_URL', '//{{ frontend_hostname }}');
-define('DPLA_API_URL', 'https://{{ api_hostname }}/v2');
-
+define('DPLA_API_URL', '{{ api_default_protocol }}://{{ api_hostname }}/v2');
 
 /** Absolute path to the WordPress directory. */
 if ( !defined('ABSPATH') )


### PR DESCRIPTION
* Add thumbp role and playbooks.

* Configure site proxy NGINX for proxying thumbnail images.

* Remove X-Forwarded-Proto coercion to 'http' in frontend's NGINX
  config, which gets in the way of proxying SSL correctly.

* Change frontend settings.local to force 'https://' for API's base URL.
  FIXME: This is probably not good.  REVIEW BEFORE SUBMITTING PR.

* Configure frontend settings.local to use scheme-relative base URL for
  Wordpress and Wordpress widgets.

* Change Wordpress's wp-config.php to use SSL and scheme-relative URLs.
  Hardcode 'https://' for API URL.
  FIXME: This hardcoding is probably not good. REVIEW BEFORE SUBMITTING
  PR.  (It won't work with development, using the VMs, yet.)