### PR TITLE
Add development support for SSL

### DIFF
--- a/README-ingestion2.md
+++ b/README-ingestion2.md
@@ -11,10 +11,7 @@ Follow all of the steps in [README.md](README.md) up until "Copy Vagrantfile.dis
 
 # Upgrade notes
 
-Release 2.2.0 upgrades PostgreSQL from 9.1 to 9.4 in order to gain significant
-performance increases by queries issued by Marmotta.  See
-[the 2.2.0 upgrade document](README-upgrade-2.2.0.txt) if you have installed
-machines with a version prior to 2.2.0.
+See the upgrade notes in [README.md](README.md).
 
 ## Steps
 
@@ -67,10 +64,28 @@ The various sites will be online at:
 * http://ingestion2.local.dp.la:8080/manager/html (Tomcat admin interface)
 * http://ingestion2.local.dp.la:8080/solr/#/ (Solr admin interface)
 * http://ldp.local.dp.la/ (Marmotta admin interface)
+* http://dev1:8008/munin/ (resource monitoring graphs)
+
+If you are using SSL (see "SSL Setup" in [README.md](README.md)), you will use
+https://local.dp.la/ for the frontend and https://local.dp.la:8080/v2/items for
+the API.
 
 There won't be any data ingested until you run an ingestion.
 
 See the rest of the main [README.md](README.md) file for more information.
+
+## SSL Setup
+
+See "SSL Setup" in [README.md](README.md).
+
+If you alternate between the `development` and `ingestion` inventories
+(for example, if you work on our legacy applications, or our content-management
+sites, in addition to Ingestion 2), they will have conflicting SSL certificates
+for `local.dp.la`. Your browser will warn you about invalid certificates, even
+if one of them is a trusted certificate in your keychain. Nothing can be done
+about this, other than replacing the trusted certificate in your keychain, or
+ignoring the browser warnings from one of the inventories.
+
 
 ## Tips
 

--- a/README-upgrade-3.0.md
+++ b/README-upgrade-3.0.md
@@ -1,0 +1,98 @@
+
+# UPGRADING TO RELEASE 3.0
+
+
+Legacy / Pre-Ingestion 2 VMs (`development` inventory)
+------------------------------------------------------
+
+Ensure that the variable `siteproxy_port` exists in `ansible/group_vars/all`
+and `ansible/group_vars/development`.
+You will need to add this if you are upgrading from an earlier version. See
+`ansible/group_vars/all.dist` and `development.dist`.  Its suggested value for
+development is "8010".  You also need to set `monitoring_http_port`, which
+we suggest you set to "8008".  Add the following two lines to your `ansible/group_vars/development` file:
+```
+monitoring_http_port: 8008
+siteproxy_port: 8010
+```
+
+Modify your existing `es_cluster_loadbal` value in `ansible/group_vars/all` and
+`ansible/group_vars/development_ingestion2` to include the port number '9201'.
+For example, in `ansible/group_vars/all`:
+```
+es_cluster_loadbal: 192.168.50.2:9201
+```
+And in `ansible/group_vars/development_ingestion2`:
+```
+es_cluster_loadbal: 192.168.50.2:9201
+```
+
+(If you're using `automation` in a staging or production environment, you
+also want to change `es_cluster_loadbal` wherever else it appears to
+include the port number.)
+
+See the new `default_http_scheme` variable in `ansible/group_vars/all.dist`.
+Make sure that your `ansible/group_vars/all` file has this variable, set to your
+liking.
+
+If you are using a local-working-copy version of the `frontend` app, make sure
+that it's current with `develop` branch, or has been rebased upon it.
+
+Log in to the `loadbal` VM:
+```
+ssh <you>@loadbal
+```
+
+Remove the existing `haproxy` and `hatop` packages, which don't support SSL ...
+```
+sudo aptitude purge hatop
+sudo aptitude purge haproxy
+exit
+```
+... And run the loadbalancer role's playbook to install and configure a more
+recent version of `haproxy` that supports SSL:
+```
+ansible-playbook -u <you> -i development playbooks/dev_loadbalancer.yml
+```
+
+If you're switching to https by modifying `default_http_scheme`, you need to
+re-run your playbooks:
+```
+ansible-playbook -u <you> -i development dev_all.yml
+```
+
+
+Ingestion 2 VMs (`ingestion` inventory)
+---------------------------------------
+
+See the first paragraphs of the section above, regarding `siteproxy_port`,
+`monitoring_port`, `default_http_scheme`, and `es_cluster_loadbal`, and
+`default_http_scheme`.
+
+If you are using a local-working-copy version of the `frontend` app, make sure
+that it's current with `develop` branch, or has been rebased upon it.
+
+Log in to the `dev1` VM:
+```
+ssh <you>@dev1
+```
+
+Remove the existing `haproxy` and `hatop` packages, which don't support SSL ...
+```
+sudo aptitude purge hatop
+sudo aptitude purge haproxy
+exit
+```
+... And run the loadbalancer role's playbook to install and configure a more
+recent version of `haproxy` that supports SSL:
+```
+ansible-playbook -u <you> -i ingestion playbooks/dev_loadbalancer.yml \
+    -e 'ingestion2=true'
+```
+
+If you're switching to https by modifying `default_http_scheme`, you need to
+re-run your playbooks:
+```
+ansible-playbook -u <you> -i ingestion dev_ingestion_all.yml
+```
+

--- a/README.md
+++ b/README.md
@@ -7,15 +7,24 @@ The intention of this project is to provide automated configuration management
 for production, development, and staging environments with the same set of
 files.
 
-## Version 2
-
-For upgrade notes, see [README-upgrade-2.0.txt](README-upgrade-2.0.txt).
+## Version 3
 
 [Release Notes](https://github.com/dpla/automation/releases)
 
-Release 2.2.0 upgrades PostgreSQL from 9.1 to 9.4.  If you have an installation
+Release 3.0 adds SSL support and introduces a variable (`siteproxy_port`) that
+must be present in `ansible/group_vars/all`; and which will need to be added if
+you are upgrading from an earlier version. See
+[README-upgrade-3.0](README-upgrade-3.0.md).
+
+Earlier versions' upgrade notes:
+
+* [README-upgrade-2.2.0.txt](README-upgrade-2.2.0.txt)
+* [README-upgrade-2.0.txt](README-upgrade-2.0.txt)
+
+Release 2.2.0 upgraded PostgreSQL from 9.1 to 9.4.  If you have an installation
 that predates [Release 2.2.0](https://github.com/dpla/automation/releases),
 please see [the 2.2.0 upgrade document](README-upgrade-2.2.0.txt) now.
+
 
 ## Installation, VM setup:
 
@@ -99,13 +108,16 @@ $ vagrant reload
 
 The various sites will be online at:
 
-* http://local.dp.la/
-* http://local.dp.la/exhibitions/
+* http://local.dp.la/ (the frontend and WordPress)
+* http://local.dp.la/exhibitions/ (the Exhibitions site)
 * http://local.dp.la:8080/v2/items (the API)
-* http://webapp1:8004/munin/  (resource monitoring graphs)
+* http://webapp1:8008/munin/  (resource monitoring graphs)
 
+If you are having the applications go over SSL (see below), you will use
+https://local.dp.la/, https://local.dp.la/exhibitions/, and
+https://local.dp.la:8080/v2/items.
 
-However, there won't be any data ingested until you run an ingestion with
+There won't be any data ingested until you run an ingestion with
 [the ingestion system](http://github.com/dpla/ingestion) and you've pointed
 it at the BigCouch instance, which will be loadbal:5984.
 
@@ -126,6 +138,30 @@ ElasticSearch search index and initialize your repositories.  Please consult
 those other projects for more information.  There's a playbook for an
 ingestion server that's not implemented yet in the development VMs.
 
+
+### SSL Setup
+
+You may set `default_http_scheme` in `ansible/group_vars/all` to control
+whether your development VM's sites go over SSL. The default is `http`, which
+means the development VMs will not use HTTPS.
+
+The development VMs use a self-signed certificate, which will cause your browser
+to issue a harsh security warning when you try to load `https://local.dp.la/`.
+We recommend that you add the `local.dp.la` SSL certificate to your operating
+system's list of trusted certificates to get around this. If you use Chrome,
+the blog for the Postman utility has an article at
+http://blog.getpostman.com/2014/01/28/using-self-signed-certificates-with-postman/
+that provides a useful walkththrough of the steps that you can take to achieve
+this. It's intended for users of Postman, which is a Chrome plugin, but will
+obviously work to get Chrome to accept the certificate, which is what you need.
+If you use another browser, the procedure should be similar. You need to
+download the certificate and add it to your certificate chain, or your operating
+system's certificate chain, with trusted status.
+
+#### Upgrading from before Version 3
+
+See the "Legacy / Pre-Ingestion 2 VMs" section of
+[README-upgrade-3.0](README-upgrade-3.0.md)
 
 ## Subsequent Usage
 

--- a/ansible/dev_ingestion_all.yml
+++ b/ansible/dev_ingestion_all.yml
@@ -28,11 +28,12 @@
 
 - include: playbooks/memcached.yml level=development
 
+- include: playbooks/common_httpd.yml level=development
+
 - name: Web Configuration (frontend and site)
   hosts: webapps
   become: yes
   roles:
-    - common_web
     - common_sitenode
     - site_proxy
     - frontend
@@ -43,21 +44,7 @@
     skip_configuration: false
     do_deployment: true
 
-- name: Web Configuration (ingestion app and marmotta)
-  # Technically, it's not necessary to specify marmotta because ingestion_app and
-  # marmotta are the same in this environment, but this is done to be throrough.
-  hosts:
-    - ingestion_app
-    - marmotta
-  become: yes
-  roles:
-    - common_web
-  vars:
-    level: development
-    ingestion2: true
-
-- include: >-
-    playbooks/api.yml level=development ingestion2=true
+- include: playbooks/api.yml level=development ingestion2=true
 
 - include: playbooks/redis.yml level=development
 

--- a/ansible/dev_ingestion_all.yml
+++ b/ansible/dev_ingestion_all.yml
@@ -36,6 +36,7 @@
     - common_sitenode
     - site_proxy
     - frontend
+    - { role: thumbp, tags: ['thumbp']}
   vars:
     level: development
     ingestion2: true

--- a/ansible/development
+++ b/ansible/development
@@ -6,7 +6,7 @@ dbnode1 ansible_ssh_host=192.168.50.4
 dbnode2 ansible_ssh_host=192.168.50.5
 
 [webapps]
-webapp1 ansible_ssh_host=192.168.50.6 monitoring_http_port=8004
+webapp1 ansible_ssh_host=192.168.50.6
 
 [frontend:children]
 webapps

--- a/ansible/files/set-allocation.sh
+++ b/ansible/files/set-allocation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 usage() {
-    echo "usage: set-allocation.sh <on|off> <target-node>"
+    echo "usage: set-allocation.sh <on|off> <target-node-and-port>"
 }
 
 if [ "x$1" != "x" ]; then
@@ -38,7 +38,7 @@ else
 fi
 
 curl_result=`echo $json | sed -e "s/SETTING/$setting/g" \
-                 | curl -s -XPUT "$node:9200/_cluster/settings" -d @-`
+                 | curl -s -XPUT "$node/_cluster/settings" -d @-`
 status_check=`echo $curl_result | awk '/"ok":true/'`
 
 if [ "$status_check" != "" ]; then

--- a/ansible/group_vars/all.dist
+++ b/ansible/group_vars/all.dist
@@ -40,8 +40,8 @@ aws_secret_key: changeme
 # We would normally get an IP address by querying the inventory, but
 # this will work easiest between development and production
 bigcouch_cluster_loadbal: 192.168.50.2
-# same with Elasticsearch ...
-es_cluster_loadbal: 192.168.50.2
+# same with Elasticsearch. Note that es_cluster_loadbal *includes the port*
+es_cluster_loadbal: 192.168.50.2:9201
 
 munin_master_ipaddr: 192.168.50.6
 
@@ -61,10 +61,10 @@ marmotta_domain: ldp.local.dp.la
 
 # HTTP ports/configuration for various applications
 #
+# default_http_scheme should not have trailing '://'
+default_http_scheme: http
 # api_port is the port the *loadbalancer* answers on for API requests
 api_port: 8080
-# api_default_protocol should not have trailing '://'
-api_default_protocol: http
 # api_app_port is the port the *backend app server* runs on
 api_app_port: 8003
 exhibitions_app_port: 8000
@@ -73,6 +73,7 @@ frontend_app_port: 8002
 ingestion_app_port: 8004
 # port 8005 is used by Tomcat
 pss_app_port: 8006
+siteproxy_port: 80
 thumbp_port: 8007
 
 nginx_real_ip_from_addrs:

--- a/ansible/group_vars/development.dist
+++ b/ansible/group_vars/development.dist
@@ -38,3 +38,6 @@ mysql_users:
 # You should set these manually in your environment.
 # slack_channel: "#channel"
 # slack_webhook_url: https://hooks.slack.com/services/XXXXX/YYYYY/ZZZZZZZZ
+
+monitoring_http_port: 8008
+siteproxy_port: 8010

--- a/ansible/group_vars/development_ingestion2.dist
+++ b/ansible/group_vars/development_ingestion2.dist
@@ -1,2 +1,3 @@
 
-es_cluster_loadbal: 192.168.50.7
+# Note that es_cluster_loadbal includes the port.
+es_cluster_loadbal: 192.168.50.7:9201

--- a/ansible/playbooks/dev_loadbalancer.yml
+++ b/ansible/playbooks/dev_loadbalancer.yml
@@ -1,7 +1,10 @@
 ---
 
+- name: Gather inventory facts in case playbook is run standalone
+  hosts: all
+
 - name: Development loadbalancer
   hosts: loadbalancer
   become: yes
   roles:
-    - dev_loadbalancer
+    - { role: dev_loadbalancer, tags: ['dev_loadbalancer', 'loadbalancer'] }

--- a/ansible/roles/api/templates/dpla.yml.j2
+++ b/ansible/roles/api/templates/dpla.yml.j2
@@ -34,7 +34,7 @@ repository:
 
 search:
   # ElasticSearch host and port
-  endpoint: {{ es_cluster_loadbal }}:9200
+  endpoint: {{ es_cluster_loadbal }}
 
   # Name of the alias pointing to your deployed ElasticSearch index
   index_name: dpla_alias

--- a/ansible/roles/dev_loadbalancer/files/certificate.sh
+++ b/ansible/roles/dev_loadbalancer/files/certificate.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+log=/tmp/certificate.log
+privkey=/etc/ssl/private/local.dp.la.key.pem
+cert=/etc/ssl/certs/local.dp.la.pem
+subj="/CN=local.dp.la"
+
+echo Starting at `date` > $log
+
+if [ -f $cert ]; then
+    echo "Certificate exists." >> $log
+    exit 0
+fi
+
+openssl req -x509 -newkey rsa:2048 -subj $subj \
+    -keyout $privkey -out /tmp/tmp.pem -days 3650 -nodes 2>&1 >> $log
+
+if [ $? -ne 0 ]; then
+    echo "Aborting." >> $log
+    exit 1
+fi
+
+cat /tmp/tmp.pem $privkey > $cert
+
+if [ $? -ne 0 ]; then
+    echo "Could not write $cert" >> $log
+    exit 1
+fi
+
+rm /tmp/tmp.pem
+
+echo "Changed." | tee -a $log

--- a/ansible/roles/dev_loadbalancer/tasks/main.yml
+++ b/ansible/roles/dev_loadbalancer/tasks/main.yml
@@ -1,22 +1,26 @@
 ---
 
+- name: Ensure that the PPA repository vbernat/haproxy-1.6 is registered
+  apt_repository: repo='ppa:vbernat/haproxy-1.6' state=present update_cache=yes
+
 - name: Install packages
-  apt: >
+  apt: >-
       pkg="{{ item }}" state=present
   with_items:
     - haproxy
     - hatop
-  tags:
-    - loadbalancer
+
+- name: Update SSL certificate
+  script: certificate.sh
+  register: script_result
+  changed_when: "'Changed' in script_result.stdout"
+  notify:
+    - restart haproxy
 
 - name: Copy haproxy init defaults file
   copy: src=etc_default_haproxy dest=/etc/default/haproxy owner=root group=root mode=0644
   notify: restart haproxy
-  tags:
-    - loadbalancer
 
 - name: Update haproxy config file
   template: src=haproxy.cfg.j2 dest=/etc/haproxy/haproxy.cfg
   notify: restart haproxy
-  tags:
-    - loadbalancer

--- a/ansible/roles/dev_loadbalancer/templates/haproxy.cfg.j2
+++ b/ansible/roles/dev_loadbalancer/templates/haproxy.cfg.j2
@@ -36,6 +36,8 @@ backend bigcouch-httpd
 	server dbnode1 192.168.50.4:5986 maxconn 500
 	server dbnode2 192.168.50.5:5986 maxconn 500
 
+{% endif %}
+
 ### Web
 
 frontend web-http-in
@@ -43,31 +45,43 @@ frontend web-http-in
 	default_backend web-http
 
 frontend web-https-in
-	bind *:443
-	default_backend web-https
+	bind *:443 ssl crt /etc/ssl/certs/local.dp.la.pem
+	mode http
+	reqadd X-Forwarded-Proto:\ https
+	default_backend web-http
 
 backend web-http
-	server webapp1 192.168.50.6:80 maxconn 500
+{% if ingestion2 is not defined %}
+	server webapp1 192.168.50.6:{{ siteproxy_port }} maxconn 500
+{% else %}
+	server dev1 192.168.50.7:{{ siteproxy_port }} maxconn 500
+{% endif %}
 
-backend web-https
-	server webapp1 192.168.50.6:443 maxconn 500
 
 ### Elasticsearch
 
 frontend elasticsearch-in
-	bind *:9200
-	default_backend elasticsearch
+    bind *:9201
+    default_backend elasticsearch
 
 backend elasticsearch
-	server dbnode1 192.168.50.4:9200 maxconn 500
-	server dbnode2 192.168.50.4:9200 maxconn 500
-
+{% if ingestion2 is not defined %}
+    server dbnode1 192.168.50.4:9200 maxconn 500
+    server dbnode2 192.168.50.4:9200 maxconn 500
+{% else %}
+    server dev1 192.168.50.7:9200 maxconn 500
 {% endif %}
 
 ### API
 
 frontend api-http-in
+{% if default_http_scheme == 'https' %}
+	bind *:{{ api_port }} ssl crt /etc/ssl/certs/local.dp.la.pem
+	reqadd X-Forwarded-Proto:\ https
+{% else %}
 	bind *:{{ api_port }}
+{% endif %}
+	mode http
 	default_backend api-http
 
 backend api-http

--- a/ansible/roles/exporter/templates/etc_cron.d_export-providers.j2
+++ b/ansible/roles/exporter/templates/etc_cron.d_export-providers.j2
@@ -1,4 +1,4 @@
-ES_URL=http://{{ es_cluster_loadbal }}:9200/dpla_alias
+ES_URL=http://{{ es_cluster_loadbal }}/dpla_alias
 OUTDIR={{ exporter_output_dir }}
 BUCKET={{ exporter_bucket }}
 PATH=/usr/local/bin:/usr/bin:/bin

--- a/ansible/roles/frontend/templates/settings.local.yml.j2
+++ b/ansible/roles/frontend/templates/settings.local.yml.j2
@@ -8,9 +8,10 @@ notifications:
 # DPLA API URL and credentials
 api:
   # Without trailing slash, please
-  url: {{ api_default_protocol }}://{{ api_hostname }}:{{ api_port }}/v2
+  url: {{ default_http_scheme }}://{{ api_hostname }}:{{ api_port }}/v2
   # API key, will be added to all API requests as &api_key=
   key: {{ api_key }}
+  verify_ssl: {{ (level == 'development') | ternary('false', 'true') }}
 exhibitions:
   # Omeka exhibition site address. Used for generating link
   site: http://{{ frontend_hostname }}/exhibitions

--- a/ansible/roles/ingestion_app/templates/config_settings.local.yml.j2
+++ b/ansible/roles/ingestion_app/templates/config_settings.local.yml.j2
@@ -20,7 +20,7 @@ marmotta:
   read_timeout: {{ ingestion_app_marmotta_read_timeout }}
 
 elasticsearch:
-  host: '{{ es_cluster_loadbal }}:9200'
+  host: '{{ es_cluster_loadbal }}'
   index_name: 'dpla_alias'
 
 prov:

--- a/ansible/roles/omeka/templates/application_config_config.ini.j2
+++ b/ansible/roles/omeka/templates/application_config_config.ini.j2
@@ -254,7 +254,7 @@ upload.maxFileSize = "50M"
 ;;;;;;;;
 
 ; adress of DPLA frontend. Required to build links
-dpla.frontendUrl = 'http://{{ frontend_hostname }}'
+dpla.frontendUrl = '//{{ frontend_hostname }}'
 
 ; address exhibit "home" page to right URL
 dpla.exhibitionsUrl = '/exhibitions'
@@ -263,7 +263,7 @@ dpla.exhibitionsUrl = '/exhibitions'
 dpla.wordpressURL = '/info'
 
 ; API URL
-dpla.apiUrl = 'http://{{ api_hostname }}:{{ api_port }}/v2'
+dpla.apiUrl = '{{ default_http_scheme }}://{{ api_hostname }}:{{ api_port }}/v2'
 
 ; API key
 dpla.apiKey = '{{ exhibitions_api_key }}';

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -134,8 +134,8 @@ upstream dpla_berkman {
 
 server {
 
-    listen   80 default;
-    listen   [::]:80 default ipv6only=on;
+    listen   {{ siteproxy_port }} default;
+    listen   [::]:{{ siteproxy_port }} default ipv6only=on;
 
     server_name {{ frontend_hostname }};
   
@@ -215,7 +215,7 @@ server {
 
     location ~ ^/api/(.*)$ {
          add_header 'Access-Control-Allow-Origin' '*';
-         rewrite ^/api/(.*)$ http://{{ api_hostname }}/$1 last;
+         rewrite ^/api/(.*)$ {{ default_http_scheme }}://{{ api_hostname }}:{{ api_port }}/$1 last;
     }
 
     location ~ ^/donate(/?|/.*)$ {
@@ -376,7 +376,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen {{ siteproxy_port }};
     server_name www.{{ frontend_hostname }};
     location / {
         rewrite ^(.*)$ http://{{ frontend_hostname }}$1 permanent;

--- a/ansible/roles/thumbp/templates/etc_init.d_thumbp.j2
+++ b/ansible/roles/thumbp/templates/etc_init.d_thumbp.j2
@@ -31,7 +31,7 @@ USER=thumbp
 GROUP=thumbp
 IF={{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['address'] }}
 IFPORT="tcp:{{ thumbp_port }}:interface=$IF"
-export ES_BASE=http://{{ es_cluster_loadbal }}:9200/dpla_alias/item
+export ES_BASE=http://{{ es_cluster_loadbal }}/dpla_alias/item
 
 usage() {
     echo >&2 "Usage: $0 <start|stop|restart|reload|status|usage>"

--- a/ansible/roles/wordpress/templates/wp-config.php.j2
+++ b/ansible/roles/wordpress/templates/wp-config.php.j2
@@ -86,7 +86,7 @@ define('WP_DEBUG_DISPLAY', {{ debug_value }});
 
 define('DPLA_API_KEY', '{{ api_key }}');
 define('DPLA_FRONTEND_URL', '//{{ frontend_hostname }}');
-define('DPLA_API_URL', '{{ api_default_protocol }}://{{ api_hostname }}/v2');
+define('DPLA_API_URL', '{{ default_http_scheme }}://{{ api_hostname }}/v2');
 
 /** Absolute path to the WordPress directory. */
 if ( !defined('ABSPATH') )


### PR DESCRIPTION
* Revise the dev_loadbalancer role so that HAProxy does SSL
* Update the `omeka` and `site_proxy` roles to allow the API to use SSL.

This PR is bound to the `frontend` changes currently under review as https://github.com/dpla/frontend/pull/83
