### PR TITLE
Do not copy `.vagrant` directories

### DIFF
--- a/ansible/roles/ingestion_app/files/copy_local_app.sh
+++ b/ansible/roles/ingestion_app/files/copy_local_app.sh
@@ -31,7 +31,7 @@ if [ ! -d /home/dpla/heidrun-mappings-local ]; then
 fi
 
 rsync -rIptl --delete --checksum \
-    --exclude '.git*' /krikri/ /home/dpla/krikri \
+    --exclude '.git*' --exclude '.vagrant' /krikri/ /home/dpla/krikri \
     || exit 1
 
 rsync -rIptl --delete --checksum \

--- a/ansible/roles/ingestion_app/files/copy_local_app.sh
+++ b/ansible/roles/ingestion_app/files/copy_local_app.sh
@@ -35,7 +35,7 @@ rsync -rIptl --delete --checksum \
     || exit 1
 
 rsync -rIptl --delete --checksum \
-    --exclude '.git*' --exclude 'log' \
+    --exclude '.git*' --exclude '.vagrant' --exclude 'log' \
     /heidrun/ /home/dpla/heidrun-local \
     || exit 1
 

--- a/ansible/roles/pss/files/copy_local_app.sh
+++ b/ansible/roles/pss/files/copy_local_app.sh
@@ -16,6 +16,7 @@ fi
 rsync -rIptl --delete --checksum \
     --exclude 'log' --exclude 'tmp' \
     --exclude 'public/uploads' \
+    --exclude '.vagrant'
     /pss_dev/ /home/dpla/pss-local
 if [ $? -ne 0 ]; then
 	exit 1


### PR DESCRIPTION
In roles that copy local development working copies of applications, exclude `.vagrant` directories.