### PR TITLE
add social media definitions to pss settings file

### DIFF
--- a/ansible/roles/pss/templates/settings.local.yml.j2
+++ b/ansible/roles/pss/templates/settings.local.yml.j2
@@ -41,3 +41,12 @@ contact_email: {{ pss_contact_email }}
 
 action_mailer:
   delivery_method: {{ pss_delivery_method }}
+
+widgets:
+  social_icons:
+    facebook: https://www.facebook.com/{{ facebook_account_name }}
+    twitter: https://twitter.com/{{ twitter_username }}
+    tumblr: http://{{ tumblr_account_name }}.tumblr.com/
+    rss: http://{{ frontend_hostname }}/info/feed
+
+twitter_username: {{ twitter_username }}


### PR DESCRIPTION
This adds social media definitions to the primary source sets settings file.  They are used for various social media sharing features in the application.  These variables are used in other frontend applications, so the values for the variables are already defined.

I used this branch to run a test deployment of pss on staging and it worked as expected.

This impacts tickets [#8383](https://issues.dp.la/issues/8383) and [#8360](https://issues.dp.la/issues/8360).

