### PR TITLE
Add thumbp group to ingestion inventory

### DIFF
--- a/ansible/ingestion
+++ b/ansible/ingestion
@@ -37,6 +37,9 @@ dev2
 [solr]
 dev2
 
+[thumbp]
+dev1
+
 [worker]
 dev2
 [worker:vars]


### PR DESCRIPTION
This fixes playbook runs for the `ingestion` inventory. The `thumbp` group was left out of https://github.com/dpla/automation/commit/efefe4b70d19e2f0d35fb89f85f1d82efb1c30bd , where it was only added to the `development` inventory.

This PR is to merge this change into a release-maintenance branch for version 2. The commit will be cherry-picked into `develop`. A release will be cut for v2.11.1 without it interfering with the pending release of version 3.
