### PR TITLE
add api url to pss

### DIFF
--- a/ansible/roles/pss/templates/settings.local.yml.j2
+++ b/ansible/roles/pss/templates/settings.local.yml.j2
@@ -13,6 +13,7 @@ exhibitions:
   url: {{ pss_exhibitions_url }}
 
 api:
+  url: {{ pss_api_url }}
   key: {{ pss_api_key }}
 
 app_scheme: {{ pss_app_scheme }}


### PR DESCRIPTION
Add the API URL to primary source sets.  This relates to [PR#153 on PSS](https://github.com/dpla/primary-source-sets/pull/153) and [PR#42 on AWS](https://github.com/dpla/aws/pull/42).