### PR TITLE
Tidy up Nginx cache-related directives

### DIFF
--- a/ansible/roles/site_proxy/defaults/main.yml
+++ b/ansible/roles/site_proxy/defaults/main.yml
@@ -42,3 +42,7 @@ siteproxy_nginx_limit_req_log_level: notice
 siteproxy_nginx_cache_max_size: 6144m
 # Size of shared memory zone that is used for NGINX cache
 siteproxy_nginx_cache_shmem_size: 360m
+# How long an item can remain in the cache without being accessed, independently
+# of how long its expiration time is, or the value of the proxy_cache_valid
+# directive:
+siteproxy_nginx_cache_inactive_time: 1d

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -6,7 +6,7 @@ proxy_cache_key       "$scheme://$host$request_uri";
 proxy_cache         staticfilecache;
 proxy_cache_valid 200 302 1d;
 proxy_cache_valid 404 1h;
-proxy_cache_valid 403 24h;
+proxy_cache_valid 403 1d;
 proxy_connect_timeout 5;
 proxy_read_timeout    120;
 proxy_send_timeout    120;

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -1,24 +1,32 @@
 
 # proxy configs
-proxy_cache_path  /var/cache/nginx levels=1:2 keys_zone=staticfilecache:{{ siteproxy_nginx_cache_shmem_size }} max_size={{ siteproxy_nginx_cache_max_size }};
+proxy_cache_path  /var/cache/nginx
+                  levels=1:2
+                  keys_zone=main_cache:{{ siteproxy_nginx_cache_shmem_size }}
+                  max_size={{ siteproxy_nginx_cache_max_size }}
+                  inactive={{ siteproxy_nginx_cache_inactive_time }};
+# TODO with NGINX >=1.7.10: set "use_temp_path=off" option to proxy_cache_path.
+# We still have NGINX v1.1.19 in Ubuntu 12.04LTS. Ubuntu 16.04LTS (Xenial)
+# provides v1.10.
 proxy_temp_path /var/spool/nginx;
-proxy_cache_key       "$scheme://$host$request_uri";
-proxy_cache         staticfilecache;
+proxy_cache_key   "$scheme://$host$request_uri";
+proxy_cache       main_cache;
 proxy_cache_valid 200 302 1d;
 proxy_cache_valid 404 1h;
 proxy_cache_valid 403 1d;
+# TODO with NGINX >= 1.5.7: set proxy_cache_revalidate to employ
+# If-Modified-Since. See note above about Ubuntu versions.
+# proxy_cache_revalidate on;
+proxy_cache_lock on;
 proxy_connect_timeout 5;
 proxy_read_timeout    120;
 proxy_send_timeout    120;
 proxy_redirect      off;
-# this causes issues with file cache - disabling :: jsd
-#proxy_buffering     off;
 
-# disable gzip for nagios checks
-gzip_disable "nagios-plugins";
-
-# use stale while updating, use next backend if error
+# Use a stale cache file in the event that another request is updating the
+# cached file. (Do not wait or try the next upstream server.)
 proxy_cache_use_stale updating;
+# Try next upstream server in the event of a failure
 proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
 
 # allows backend to see real ip
@@ -203,7 +211,10 @@ server {
     }
 
     location /thumb {
-        proxy_cache_use_stale error timeout http_500 http_503;
+        # Move on to next origin server in the event of connection error or
+        # timeout via proxy_next_upstream (above), but deliver stale file for
+        # a 500 or 503, assuming the other server won't respond any better.
+        proxy_cache_use_stale updating http_500 http_503;
         expires 10d;
         add_header Cache-Control "public";
         proxy_pass http://dpla_thumbp;
@@ -272,7 +283,7 @@ server {
                 set $do_not_cache 1;
             }
             proxy_cache_key     "$scheme://$host$request_uri $do_not_cache";
-            proxy_cache staticfilecache;
+            proxy_cache main_cache;
         }
 
         location ~* \/[^\/]+\/(feed|\.xml)\/? {

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -4,7 +4,7 @@ proxy_cache_path  /var/cache/nginx levels=1:2 keys_zone=staticfilecache:{{ sitep
 proxy_temp_path /var/spool/nginx;
 proxy_cache_key       "$scheme://$host$request_uri";
 proxy_cache         staticfilecache;
-proxy_cache_valid 200 302 24h;
+proxy_cache_valid 200 302 1d;
 proxy_cache_valid 404 1h;
 proxy_cache_valid 403 24h;
 proxy_connect_timeout 5;

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -4,6 +4,9 @@ proxy_cache_path  /var/cache/nginx levels=1:2 keys_zone=staticfilecache:{{ sitep
 proxy_temp_path /var/spool/nginx;
 proxy_cache_key       "$scheme://$host$request_uri";
 proxy_cache         staticfilecache;
+proxy_cache_valid 200 302 24h;
+proxy_cache_valid 404 1h;
+proxy_cache_valid 403 24h;
 proxy_connect_timeout 5;
 proxy_read_timeout    120;
 proxy_send_timeout    120;
@@ -153,8 +156,6 @@ server {
 
     location / {
 
-        proxy_cache_valid 200 240m;
-
         # Ignore cache-disabling headers set by the portal app
         proxy_ignore_headers Cache-Control Set-Cookie;
 
@@ -171,9 +172,8 @@ server {
         }
 
         location ~* \.(jpg|png|gif|jpeg|css|js|mp3|wav|swf|mov|doc|pdf|xls|ppt|docx|pptx|xlsx)$ {
-            # Cache static-looking files for 120 minutes, setting a 10 day expiry time.
-            proxy_cache_valid 200 360m;
-            expires 864000;
+            # 10 day expiry time for static files
+            expires 10d;
             proxy_pass http://dpla_portal;
         }
 
@@ -194,7 +194,6 @@ server {
         # redundant with `location /` above.
         proxy_cache off;
         # TODO:  consider selective caching, but watch out for Content-Type
-        # proxy_cache_valid 200 240m;
         # proxy_ignore_headers Cache-Control Set-Cookie;
         # proxy_cache_key       "$request_uri$http_content_type";
         proxy_pass http://dpla_portal;
@@ -204,11 +203,8 @@ server {
     }
 
     location /thumb {
-        proxy_cache_valid 200 60m;
-        proxy_cache_valid 404 1h;
-        proxy_cache_valid 403 24h;
         proxy_cache_use_stale error timeout http_500 http_503;
-        expires 1d;
+        expires 10d;
         add_header Cache-Control "public";
         proxy_pass http://dpla_thumbp;
     }
@@ -224,7 +220,6 @@ server {
 
 {% if groups['cms'] is defined %}
     location /info {
-        proxy_cache_valid 200 240m;
         proxy_cache_bypass        $http_cache_bypass $cookie_wordpress_logged_in;
         proxy_no_cache            $http_cache_bypass $cookie_wordpress_logged_in;
 
@@ -258,8 +253,7 @@ server {
         location ~* \.(jpg|png|gif|jpeg|css|js|mp3|wav|swf|mov|doc|pdf|xls|ppt|docx|pptx|xlsx)$ {
             # Cache static-looking files for 120 minutes, setting a 10 day expiry time.
             # Do not cache for logged-in users.
-            proxy_cache_valid 200 360m;
-            expires 864000;
+            expires 10d;
             if ($http_cookie ~* "comment_author_|wordpress_(?!test_cookie)|wp-postpass_" ) {
                 set $do_not_cache 1;
             }
@@ -282,14 +276,12 @@ server {
         }
 
         location ~* \/[^\/]+\/(feed|\.xml)\/? {
-            proxy_cache_valid 200 240m;
             limit_conn defaultconnzone 3;
             limit_req zone=defaultreqzone burst={{ siteproxy_nginx_default_req_burst }};
             if ($http_cookie ~* "comment_author_|wordpress_(?!test_cookie)|wp-postpass_" ) {
                 set $do_not_cache 1;
             }
             proxy_cache_key     "$scheme://$host$request_uri $do_not_cache";
-            proxy_cache_valid 200 240m;
             proxy_pass http://dpla_wp;
         }
 
@@ -309,8 +301,7 @@ server {
         # Do not cache HTML, but cache static files
         proxy_cache off;
         location ~* \.(css|doc|docx|flv|gif|htm|ico|jpeg|jpg|js|m4v|mov|mp3|mp4|pdf|png|ppt|pptx|swf|svg|svgz|tif|ttf|wav|xls|xlsx)$ {
-            proxy_cache_valid 200 360m;
-            expires 864000;
+            expires 10d;
             proxy_pass http://dpla_omeka;
         }
 
@@ -339,8 +330,7 @@ server {
         proxy_cache off;
 
         location ~* \.(css|png|js|jpe?g|ico|mov|mp3|mp4|pdf)$ {
-            proxy_cache_valid 200 360m;
-            expires 864000;
+            expires 10d;
             proxy_pass http://dpla_pss;
         }
 


### PR DESCRIPTION
* Have one set of proxy_cache_valid settings
* Express 'expires' with more easily-read "days" format
* Remove redundant proxy_cache_valid directives. There was some variation, but not enough for it to be perpetuated.

My original reason for modifying the proxy Nginx configuration was to make caching more effective for `thumbp`, but I decided it needed some cleanup.
