### PR TITLE
Add apt-show-versions utility to common role

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -53,6 +53,7 @@
     - zlib1g-dev
     - debian-goodies
     - python-apt
+    - apt-show-versions
   tags:
     - packages
     - munin


### PR DESCRIPTION
Add the apt-show-versions package to the list that is installed by the common role. This adds the command of the same name, which is a little easier to use than `aptitude` for determining which packages need to be upgraded.

Example usage:
```
$ ssh you@server apt-show-versions -u
```