### PR TITLE
Add ImageMagick policy.xml file

### DIFF
--- a/ansible/files/imagemagick_policy.xml
+++ b/ansible/files/imagemagick_policy.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+<!ELEMENT policymap (policy)+>
+<!ELEMENT policy (#PCDATA)>
+<!ATTLIST policy domain (delegate|coder|filter|path|resource) #IMPLIED>
+<!ATTLIST policy name CDATA #IMPLIED>
+<!ATTLIST policy rights CDATA #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
+]>
+<!--
+  Configure ImageMagick policies.
+
+  Domains include system, delegate, coder, filter, path, or resource.
+
+  Rights include none, read, write, and execute.  Use | to combine them,
+  for example: "read | write" to permit read from, or write to, a path.
+
+  Use a glob expression as a pattern.
+
+  Suppose we do not want users to process MPEG video images:
+
+    <policy domain="delegate" rights="none" pattern="mpeg:decode" />
+
+  Here we do not want users reading images from HTTP:
+
+    <policy domain="coder" rights="none" pattern="HTTP" />
+
+  Lets prevent users from executing any image filters:
+
+    <policy domain="filter" rights="none" pattern="*" />
+
+  The /repository file system is restricted to read only. We use a glob
+  expression to match all paths that start with /repository:
+
+    <policy domain="path" rights="read" pattern="/repository/*" />
+
+  Any large image is cached to disk rather than memory:
+
+    <policy domain="resource" name="area" value="1gb"/>
+
+  Note, resource policies are maximums for each instance of ImageMagick (e.g.
+  policy memory limit 1GB, -limit 2GB exceeds policy maximum so memory limit
+  is 1GB).
+-->
+<policymap>
+    <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+    <policy domain="coder" rights="none" pattern="URL" />
+    <policy domain="coder" rights="none" pattern="HTTPS" />
+    <policy domain="coder" rights="none" pattern="MVG" />
+    <policy domain="coder" rights="none" pattern="MSL" />
+    <policy domain="coder" rights="none" pattern="TEXT" />
+    <policy domain="coder" rights="none" pattern="SHOW" />
+    <policy domain="coder" rights="none" pattern="WIN" />
+    <policy domain="coder" rights="none" pattern="PLT" />
+</policymap>

--- a/ansible/roles/common_php/handlers/main.yml
+++ b/ansible/roles/common_php/handlers/main.yml
@@ -2,3 +2,6 @@
 
 - name: reload php
   service: name=php5-fpm state=reloaded
+
+- name: restart php
+  service: name=php5-fpm state=restarted

--- a/ansible/roles/common_php/tasks/main.yml
+++ b/ansible/roles/common_php/tasks/main.yml
@@ -16,6 +16,20 @@
     - web
     - php
 
+- name: Ensure state of ImageMagick policy.xml file
+  # This is configured here because php5-imagick depends on imagemagick-common
+  # and the policy.xml file is part of that package.
+  copy:
+    src: ../../../files/imagemagick_policy.xml
+    dest: /etc/ImageMagick/policy.xml
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart php
+  tags:
+    - web
+    - php
+
 - name: Update PHP configuration (php.ini)
   template: >-
       src=php.ini.j2 dest=/etc/php5/fpm/php.ini

--- a/ansible/roles/frontend/handlers/main.yml
+++ b/ansible/roles/frontend/handlers/main.yml
@@ -7,3 +7,6 @@
   delegate_to: "{{ item }}"
   with_items: groups.memcached
   service: name=memcached state=restarted
+
+- name: restart unicorn
+  service: name=unicorn_frontend state=restarted

--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -15,6 +15,15 @@
   tags:
     - packages
 
+- name: Ensure state of ImageMagick policy.xml file
+  copy:
+    src: ../../../files/imagemagick_policy.xml
+    dest: /etc/ImageMagick/policy.xml
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart unicorn
+
 - name: Ensure state of Unicorn init script
   template: >
       src=etc_init.d_unicorn_frontend.j2 dest=/etc/init.d/unicorn_frontend

--- a/ansible/roles/omeka/tasks/main.yml
+++ b/ansible/roles/omeka/tasks/main.yml
@@ -7,6 +7,8 @@
     - php
     - web
 
+# ImageMagick policy.xml file is configured by common_php role.
+
 - name: Update php-fpm pool for Omeka
   template: >
       src=etc_php5_fpm_pool.d_omeka.conf.j2


### PR DESCRIPTION
Add ImageMagick file: `/etc/ImageMagick/policy.xml`

The immediate concern is to fix the recently-announced ImageTragick exploit:
* https://imagetragick.com/
* https://bugs.launchpad.net/ubuntu/%2Bsource/imagemagick/%2Bbug/1578398

Note the conversation in the Ubuntu bugtracker in which the maintainer critiques the response from the ImageMagick upstream developers. Even though they have released a patch version (6.9.3-10) that they claim fixes the problem, the maintainer advocates that it is not sufficient. He provides some alternative approaches in http://www.openwall.com/lists/oss-security/2016/05/03/19, including the removal of the "delegate" functionality altogether, which does not seem appropriate.

The fact that this debate is going on indicates to me that it is a good idea for us to have our own `policy.xml` file whatever the case to be have more control over ImageMagick's workings.