### PR TITLE
Fix/munin postgres plugin patch

### DIFF
--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -213,3 +213,40 @@
   tags:
     - munin
     - postgresql
+
+# Update queries in following munin plugins so they reference correct
+# PostgreSQL 9.4 column names
+#
+#   * postgres_connections_
+#   * postgres_connections_db
+#   * postgres_users
+#   * postgres_querylength_
+- name: Patch plugins - replace 'procpid' with 'pid'
+  replace: >-
+    dest='/usr/share/munin/plugins/{{ item }}'
+    regexp='\sprocpid'
+    replace=' pid '
+    backup=yes
+  with_items:
+    - postgres_connections_
+    - postgres_connections_db
+    - postgres_users
+    - postgres_querylength_
+  tags:
+    - munin
+    - postgresql
+
+- name: Patch plugins - replace 'current_query' with 'query'
+  replace: >-
+    dest='/usr/share/munin/plugins/{{ item }}'
+    regexp='\scurrent_query'
+    replace=' query '
+    backup=yes
+  with_items:
+    - postgres_connections_
+    - postgres_connections_db
+    - postgres_users
+    - postgres_querylength_
+  tags:
+    - munin
+    - postgresql


### PR DESCRIPTION
Addresses https://issues.dp.la/issues/8146 by adding tasks to find and replace Postgres 9.1 column names (current_query, procpid) with 9.4 column names (query, pid) in queries in the following munin plugins: 

- postgres_querylength_ 
- postgres_connections_
- postgres_connections_db
- postgres_users

Do not merge yet (need to squash)
