### PR TITLE
Fix siteproxy wait_for_host port number

### DIFF
--- a/ansible/playbooks/siteproxy.yml
+++ b/ansible/playbooks/siteproxy.yml
@@ -38,7 +38,8 @@
     - name: Wait for site proxy node to come back up
       become: false
       local_action: >
-          wait_for host="{{ inventory_hostname }}" port=80 delay=2 timeout=30
+          wait_for host="{{ inventory_hostname }}" port={{ siteproxy_port }}
+          delay=2 timeout=30
     - name: Register instance with loadbalancer again
       # Note that, on initialization of the whole environment, when there are no
       # origin servers yet behind the loadbalancer, this task could fail if the loadbalancer


### PR DESCRIPTION
Fix siteproxy playbook's "Wait for site proxy node to come back up" task so that it uses the correct port number for the wait_for module. The port number is different in the development environment that it is
elsewhere.