### PR TITLE
Fix RAILS_ENV and rsync in frontend deployment

### DIFF
--- a/ansible/playbooks/deploy_frontend.yml
+++ b/ansible/playbooks/deploy_frontend.yml
@@ -12,3 +12,5 @@
   vars:
     do_deployment: true
     skip_configuration: true
+  environment:
+    RAILS_ENV: "{{ frontend_rails_env }}"

--- a/ansible/playbooks/frontend.yml
+++ b/ansible/playbooks/frontend.yml
@@ -12,3 +12,5 @@
   vars:
     do_deployment: true
     skip_configuration: false
+  environment:
+    RAILS_ENV: "{{ frontend_rails_env }}"

--- a/ansible/roles/frontend/files/copy_local_app.sh
+++ b/ansible/roles/frontend/files/copy_local_app.sh
@@ -15,7 +15,7 @@ fi
 
 rsync -rIptl --delete --checksum \
     --exclude 'log' --exclude 'tmp' --exclude 'vendor/assets' \
-    --exclude 'public/uploads' \
+    --exclude 'public/assets' --exclude 'public/uploads' \
     /frontend_dev/ /home/dpla/frontend-local
 if [ $? -ne 0 ]; then
 	exit 1


### PR DESCRIPTION
* Add missing assignment of RAILS_ENV to frontend deployment

* Add exclusion for `public/assets` directory in local copy during frontend deployment.

This mostly affects development deployments.
