### PR TITLE
Add default for pss_api_url variable

### DIFF
--- a/ansible/roles/pss/defaults/main.yml
+++ b/ansible/roles/pss/defaults/main.yml
@@ -31,3 +31,4 @@ pss_include_branding: false
 # /srv/www/pss/tmp/mails.
 pss_delivery_method: file
 pss_api_key: aa11d0958e93bb25e457a726dc10a40f
+pss_api_url: "//{{ api_hostname }}:{{ api_port }}"


### PR DESCRIPTION
Add a role default for `pss_api_url`, which was added in https://github.com/dpla/automation/commit/47625481760b6237c8d8520288ba771d6db72e12.
