### PR TITLE
Improve NGINX cache configuration

### DIFF
--- a/ansible/roles/site_proxy/defaults/main.yml
+++ b/ansible/roles/site_proxy/defaults/main.yml
@@ -42,3 +42,7 @@ siteproxy_nginx_limit_req_log_level: notice
 siteproxy_nginx_cache_max_size: 6144m
 # Size of shared memory zone that is used for NGINX cache
 siteproxy_nginx_cache_shmem_size: 360m
+# How long an item can remain in the cache without being accessed, independently
+# of how long its expiration time is, or the value of the proxy_cache_valid
+# directive:
+siteproxy_nginx_cache_inactive_time: 1d

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -1,21 +1,33 @@
 
 # proxy configs
-proxy_cache_path  /var/cache/nginx levels=1:2 keys_zone=staticfilecache:{{ siteproxy_nginx_cache_shmem_size }} max_size={{ siteproxy_nginx_cache_max_size }};
+proxy_cache_path  /var/cache/nginx
+                  levels=1:2
+                  keys_zone=main_cache:{{ siteproxy_nginx_cache_shmem_size }}
+                  max_size={{ siteproxy_nginx_cache_max_size }}
+                  inactive={{ siteproxy_nginx_cache_inactive_time }};
+# TODO with NGINX >=1.7.10: set "use_temp_path=off" option to proxy_cache_path.
+# We still have NGINX v1.1.19 in Ubuntu 12.04LTS. Ubuntu 16.04LTS (Xenial)
+# provides v1.10.
 proxy_temp_path /var/spool/nginx;
-proxy_cache_key       "$scheme://$host$request_uri";
-proxy_cache         staticfilecache;
+proxy_cache_key   "$scheme://$host$request_uri";
+proxy_cache       main_cache;
+# see proxy_cache_valid directives for successes in location blocks
+proxy_cache_valid 404 1h;
+proxy_cache_valid 403 1d;
+# TODO with NGINX >= 1.5.7: set proxy_cache_revalidate to employ
+# If-Modified-Since. See note above about Ubuntu versions.
+# proxy_cache_revalidate on;
+proxy_cache_lock on;
 proxy_connect_timeout 5;
 proxy_read_timeout    120;
 proxy_send_timeout    120;
 proxy_redirect      off;
-# this causes issues with file cache - disabling :: jsd
-#proxy_buffering     off;
+proxy_hide_header "X-Powered-By";
 
-# disable gzip for nagios checks
-gzip_disable "nagios-plugins";
-
-# use stale while updating, use next backend if error
+# Use a stale cache file in the event that another request is updating the
+# cached file. (Do not wait or try the next upstream server.)
 proxy_cache_use_stale updating;
+# Try next upstream server in the event of a failure
 proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
 
 # allows backend to see real ip
@@ -26,12 +38,30 @@ proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
 # allows us to check the page's cache status
 add_header X-Cache-Status $upstream_cache_status;
 
-# adding a header cache_bypass:true will invalidate and recache a specific page
-proxy_cache_bypass        $http_cache_bypass $cookie__dpla_no_cache $do_not_cache;
-proxy_no_cache            $http_cache_bypass $cookie__dpla_no_cache $do_not_cache;
+map_hash_bucket_size 128;  # Must come before all map directives
 
-# Need to set up a map of this size.
-map_hash_bucket_size 128;
+map $http_content_type $do_not_cache_ctype {
+    default            0;
+    "application/json" 1;
+}
+
+# Our Wordpress doesn't set cookies, except for during admin use. We want to
+# exclude admin requests from being cached. The map must be defined here in
+# the http{} context. See below in the /info location block.
+map $http_cookie $do_not_cache_wp_cookie {
+    default                        0;
+    "~comment_author_"             1;
+    "~wordpress_"                  1;
+    "~wp-postpass_"                1;
+    "wordpress_logged_in"          1;
+}
+
+
+# The variable $do_not_cache == 1 will cause the request to bypass the cache,
+# and will result in the response not being cached.
+proxy_cache_bypass $do_not_cache_ctype;
+proxy_no_cache     $do_not_cache_ctype;
+
 map $http_user_agent $bad_bot{
     default     0;
     "Mozilla/4.0 (compatible; ICS)"     1;
@@ -54,11 +84,6 @@ map $http_user_agent $bad_bot{
     "0"         1;
     "Mozilla/5.0 (compatible; SiteBot/0.1; +http://www.sitebot.org/robot/)"     1;
     "Pcore-HTTP/v0.18.1"    1;
-}
-
-map $http_content_type $do_not_cache {
-    default         0;  
-    "application/json"      1;  
 }
 
 # Addresses that are not subject to rate or connection limiting
@@ -140,8 +165,6 @@ server {
         return 403;
     }
 
-    set $do_not_cache 0;
-
 {% for addr in nginx_real_ip_from_addrs %}
     set_real_ip_from {{ addr }};
 {% endfor %}
@@ -149,27 +172,60 @@ server {
 
     location / {
 
-        proxy_cache_valid 200 240m;
+        # In order to get caching to work, we used to have a
+        # proxy_ignore_headers directive here to ignore Cache-Control and
+        # Set-Cookie. As a result, we were caching responses along with their
+        # Set-Cookie headers.  We were bypassing cache lookup and storage for
+        # requests from logged-in users (by looking for the "_dpla_no_cache"
+        # cookie) but we were storing Set-Cookie response headers for other
+        # requests, which does not seem right.
+        #
+        # FIXME: Improve caching by having the frontend app stop assigning any
+        # session cookies unless they are necessary for logins.  Come back here
+        # and adjust caching and expiration when the frontend can make smart
+        # choices about what should be cached, and can set its own cache-related
+        # headers.
+        #
+        # Note, however, that, as of v21.1.3 of `frontend`, the Set-Cookie
+        # header is set much less frequently, freeing the browser to use
+        # If-None-Match requests.  This provides a good combination of
+        # performance and content freshness.  It should no longer be necessary
+        # to flush the proxy cache for HTML updates.  Requests for pages that
+        # have already been seen will now result in a 304 Not Modified, unless
+        # they have been modified.
+        # (https://github.com/dpla/frontend/commit/0f1085f5c6d4b0c6f265866cb68384f969c53f54)
 
-        # Ignore cache-disabling headers set by the portal app
-        proxy_ignore_headers Cache-Control Set-Cookie;
+        proxy_pass http://dpla_portal;
+        proxy_cache off;
 
         # Up to 10 simultaneous page requests per IP 
         limit_conn defaultconnzone {{ siteproxy_nginx_default_max_conn }};
         # Up to 20 requests / sec for pages.
         limit_req zone=defaultreqzone burst={{ siteproxy_nginx_default_req_burst }};
     
-        proxy_pass          http://dpla_portal;
-
-        # robots.txt
-        location ~ ^/robots.txt$ {
+        location /robots.txt {
             alias /srv/www/robots.txt;
         }
 
-        location ~* \.(jpg|png|gif|jpeg|css|js|mp3|wav|swf|mov|doc|pdf|xls|ppt|docx|pptx|xlsx)$ {
-            # Cache static-looking files for 120 minutes, setting a 10 day expiry time.
-            proxy_cache_valid 200 360m;
-            expires 864000;
+        location /assets {
+            # FIXME:
+            # It would be great to extend the expiration of frontend assets,
+            # but there are still some that the `frontend` app does not seem
+            # to compile and assign versioned names.
+            proxy_pass http://dpla_portal;
+            proxy_cache main_cache;
+            proxy_cache_valid 200 301 302 404 1m;
+            expires 1m;
+            add_header Cache-Control "public";
+            add_header X-Cache-Status $upstream_cache_status;
+        }
+
+        location /saved {
+            proxy_cache off;
+            proxy_pass http://dpla_portal;
+        }
+        location /users {
+            proxy_cache off;
             proxy_pass http://dpla_portal;
         }
 
@@ -190,7 +246,6 @@ server {
         # redundant with `location /` above.
         proxy_cache off;
         # TODO:  consider selective caching, but watch out for Content-Type
-        # proxy_cache_valid 200 240m;
         # proxy_ignore_headers Cache-Control Set-Cookie;
         # proxy_cache_key       "$request_uri$http_content_type";
         proxy_pass http://dpla_portal;
@@ -200,12 +255,14 @@ server {
     }
 
     location /thumb {
-        proxy_cache_valid 200 60m;
-        proxy_cache_valid 404 1h;
-        proxy_cache_valid 403 24h;
-        proxy_cache_use_stale error timeout http_500 http_503;
-        expires 1d;
+        # Move on to next origin server in the event of connection error or
+        # timeout via proxy_next_upstream (above), but deliver stale file for
+        # a 500 or 503, assuming the other server won't respond any better.
+        proxy_cache_use_stale updating http_500 http_503;
+        proxy_cache_valid 10d;
+        expires 10d;
         add_header Cache-Control "public";
+        add_header X-Cache-Status $upstream_cache_status;
         proxy_pass http://dpla_thumbp;
     }
 
@@ -220,20 +277,22 @@ server {
 
 {% if groups['cms'] is defined %}
     location /info {
-        proxy_cache_valid 200 240m;
-        proxy_cache_bypass        $http_cache_bypass $cookie_wordpress_logged_in;
-        proxy_no_cache            $http_cache_bypass $cookie_wordpress_logged_in;
+
+        proxy_pass          http://dpla_wp;
+
+        proxy_cache_valid 1m;  # 1 minute
+        expires 1m;
+
+        proxy_cache_bypass $do_not_cache_ctype $do_not_cache_wp_cookie;
+        proxy_no_cache     $do_not_cache_ctype $do_not_cache_wp_cookie;
+
+        add_header Cache-Control "public";
+        add_header X-Cache-Status $upstream_cache_status;
 
         # Up to 10 simultaneous page requests per IP
         limit_conn defaultconnzone {{ siteproxy_nginx_default_max_conn }};
         # Up to 20 requests / sec for pages.
         limit_req zone=defaultreqzone burst={{ siteproxy_nginx_default_req_burst }};
-        if ($http_cookie ~* "comment_author_|wordpress_(?!test_cookie)|wp-postpass_" ) {
-            set $do_not_cache 1;
-        }
-
-        proxy_cache_key     "$scheme://$host$request_uri $do_not_cache";
-        proxy_pass          http://dpla_wp;
 
         # 502 and 504 errors are usually going to be the result of Nginx on the
         # content management server being offline for a reboot, so return a
@@ -250,49 +309,34 @@ server {
         rewrite ^/info/get-involved/forums /info/forums permanent;
         rewrite ^/info/about/org /info/about/policies permanent;
 
-        # static files 
-        location ~* \.(jpg|png|gif|jpeg|css|js|mp3|wav|swf|mov|doc|pdf|xls|ppt|docx|pptx|xlsx)$ {
-            # Cache static-looking files for 120 minutes, setting a 10 day expiry time.
-            # Do not cache for logged-in users.
-            proxy_cache_valid 200 360m;
-            expires 864000;
-            if ($http_cookie ~* "comment_author_|wordpress_(?!test_cookie)|wp-postpass_" ) {
-                set $do_not_cache 1;
-            }
-            proxy_cache_key     "$scheme://$host$request_uri $do_not_cache";
+        # Assets in /info/wp-includes can be counted upon to be versioned with
+        # querystrings, like /info/wp-includes/js/jquery.js?ver=1.12.3.
+        # It is, therefore, safe to set a long cache-valid time and browser
+        # cache expiration.
+        location /info/wp-includes {
+            proxy_cache_valid 1M;  # 1 month
+            expires 1M;
             proxy_pass http://dpla_wp;
+            add_header X-Cache-Status $upstream_cache_status;
+        }
+        # Same with plugins ...
+        location /info/wp-content/plugins {
+            proxy_cache_valid 1M; # 1 month
+            expires 1M;
+            proxy_pass http://dpla_wp;
+            add_header X-Cache-Status $upstream_cache_status;
         }
 
         rewrite /wp-admin$ $scheme://$host$uri/ permanent;
         location ~* wp\-.*\.php|wp\-admin {
+            proxy_cache off;
+            expires off;
             proxy_pass http://dpla_wp;
-        }
-
-        location ~* test\.php {
-            # Cache for non-logged-in users.
-            if ($http_cookie ~* "comment_author_|wordpress_(?!test_cookie)|wp-postpass_" ) {
-                set $do_not_cache 1;
-            }
-            proxy_cache_key     "$scheme://$host$request_uri $do_not_cache";
-            proxy_cache staticfilecache;
         }
 
         location ~* \/[^\/]+\/(feed|\.xml)\/? {
-            proxy_cache_valid 200 240m;
             limit_conn defaultconnzone 3;
             limit_req zone=defaultreqzone burst={{ siteproxy_nginx_default_req_burst }};
-            if ($http_cookie ~* "comment_author_|wordpress_(?!test_cookie)|wp-postpass_" ) {
-                set $do_not_cache 1;
-            }
-            proxy_cache_key     "$scheme://$host$request_uri $do_not_cache";
-            proxy_cache_valid 200 240m;
-            proxy_pass http://dpla_wp;
-        }
-
-        location ~* ^\/(apc|phpinfo)\.php {
-            access_log off;
-            allow 127.0.0.1;
-            deny all;
             proxy_pass http://dpla_wp;
         }
 
@@ -301,12 +345,14 @@ server {
     location /exhibitions {
 
         proxy_pass          http://dpla_omeka;
-
-        # Do not cache HTML, but cache static files
         proxy_cache off;
+
         location ~* \.(css|doc|docx|flv|gif|htm|ico|jpeg|jpg|js|m4v|mov|mp3|mp4|pdf|png|ppt|pptx|swf|svg|svgz|tif|ttf|wav|xls|xlsx)$ {
-            proxy_cache_valid 200 360m;
-            expires 864000;
+            proxy_cache main_cache;
+            proxy_cache_valid 200 301 302 404 1m;
+            expires 1m;
+            add_header Cache-Control "public";
+            add_header X-Cache-Status $upstream_cache_status;
             proxy_pass http://dpla_omeka;
         }
 
@@ -334,9 +380,12 @@ server {
         proxy_pass http://dpla_pss;
         proxy_cache off;
 
-        location ~* \.(css|png|js|jpe?g|ico|mov|mp3|mp4|pdf)$ {
-            proxy_cache_valid 200 360m;
-            expires 864000;
+        location /primary-source-sets/assets {
+            proxy_cache main_cache;
+            proxy_cache_valid 200 301 302 404 10d;
+            expires 10d;
+            add_header Cache-Control "public";
+            add_header X-Cache-Status $upstream_cache_status;
             proxy_pass http://dpla_pss;
         }
 


### PR DESCRIPTION
The goal of these changes was originally to cache `/thumb` resources, but it became apparent that we could do better in caching overall.

With this commit, and some work on the frontend app, it will be possible some day to forego the cache-purging that we usually do after a deployment.

* Reduce the number of proxy_cache_valid directives.

* Express 'expires' with date units.

* Remove redundant proxy_cache_valid directives. There was some variation, but not enough for it to be perpetuated.

* Rename shared memory zone from "staticfilecache" to "main_cache" because it's not simply a static file cache.

* Add "inactive" parameter to proxy_cache_path, which was defaulting to 10 minutes.

* Add note about proxy_cache_revalidate (NGINX sends If-Modified-Since to origin).  We can't use it because we're still on Ubuntu 12.04LTS, with NGINX 1.1.

* Add proxy_cache_lock so concurrent requests don't get sent to origin server for the same thing.

* Change some comments.

* Change proxy_cache_use_stale for /thumbp location. Move on to next origin server in the event of connection error or timeout via proxy_next_upstream, but deliver stale file for a 500 or 503, assuming the other server won't respond any better.

* Add Cache-Control and X-Cache-Status headers to individual locations

* Hide X-Powered-By header.

* Shorten expiration time of Exhibitions assets.

* Enable caching of Primary Source Sets assets.

* Have the cache store 301 responses in a number of locations.

* Remove test.php and phpinfo.php locations within /info location.

* Make proxy_cache_key consistent across configuration.

* Remove ability to defeat caching by setting Cache-Bypass header.

* Simplify use of proxy_cache_bypass and proxy_no_cache.

It would be great to extend the expiration of frontend assets, but there are still some that the `frontend` app does not seem to compile and assign cache-extending names. The expiration for assets in the frontend therefore is one minute.

Wordpress assets in wp-includes and in plugins are versioned, but those in the berkman theme are not. No image assets are versioned. The expiration for the wordpress site for anonymous users (who do not have the relevant cookies) is one minute for most resources and one month for the versioned assets.

These changes don't fix the development environment's longstanding asset-pipeline problems. The frontend has uncompiled assets that shouldn't be cached for long periods. The deployments still clear the proxy cache, so this is OK for the meantime. In the future, we need to clear the cache conditionally: clear it after a deployment only in the development environment, and let asset versioning do the job in production.

The `_dpla_no_cache` cookie for the frontend should still be recognized because it still applies to admin requests. For caching to be optimal, the frontend app needs to be modified to set the `_dpla_no_cache` header only when necessary, not with every single request. It should only be set when an admin logs in or out. The `/saved` and `/users` locations have caching disabled for regular users who are logged in.

We don't cache the frontend app's HTML because it's too problematic for loggged-in users and the app library. Applications should be in charge of setting good cache headers for authenticated and unauthenticated requests, and it's bad to second-guess them in the proxy configuration.
