### PR TITLE
Facilitate dynamic inventory and custom environments

### DIFF
--- a/ansible/roles/api/defaults/main.yml
+++ b/ansible/roles/api/defaults/main.yml
@@ -6,3 +6,4 @@ api_branch_or_tag: master
 api_rails_env: development
 api_rbenv_version: 1.9.3-p547
 api_alternate_db_host: false
+api_index_name: dpla_alias

--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -11,7 +11,7 @@
     - libreadline6
     - libreadline6-dev
     - zip
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - packages
 
@@ -19,7 +19,7 @@
   template: >
       src=etc_init.d_unicorn_api.j2 dest=/etc/init.d/unicorn_api
       owner=root group=root mode=0755
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - web
     - initscripts
@@ -28,20 +28,20 @@
   template: >
       src=start_unicorn_api.sh.j2 dest=/usr/local/sbin/start_unicorn_api.sh
       owner=root group=root mode=0755
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - web
 
 - name: Clear existing unicorn init script run levels in case of change
   command: update-rc.d -f unicorn_api remove
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - web
     - initscripts
 
 - name: Ensure Unicorn init script run levels
   command: update-rc.d unicorn_api defaults 21 18
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - web
     - initscripts
@@ -81,7 +81,7 @@
 - name: Ensure that obsolete QA app htpasswd file is absent
   file: path=/etc/nginx/qa_htpasswd state=absent
   notify: restart nginx
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - nginx
     - web
@@ -95,7 +95,7 @@
       dest="/etc/nginx/sites-available/api"
       owner=root group=root mode=0644
   notify: restart nginx
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - nginx
     - web
@@ -106,7 +106,7 @@
       dest="/etc/nginx/sites-enabled/api"
       state=link owner=root group=root
   notify: restart nginx
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - nginx
     - web
@@ -116,7 +116,7 @@
       src=etc_logrotate.d_api_rails_logs.j2
       dest=/etc/logrotate.d/api_rails_logs
       owner=root group=root mode=0644
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - logrotate
 

--- a/ansible/roles/api/templates/database.yml.j2
+++ b/ansible/roles/api/templates/database.yml.j2
@@ -19,7 +19,6 @@ development:
   adapter: postgresql
   encoding: unicode
   host: {{ db_host }}
-  hostname: localhost
   database: api
   username: {{ postgresql_user['name'] }}
   password: {{ postgresql_user['password'] }}

--- a/ansible/roles/api/templates/dpla.yml.j2
+++ b/ansible/roles/api/templates/dpla.yml.j2
@@ -37,7 +37,7 @@ search:
   endpoint: {{ es_cluster_loadbal }}
 
   # Name of the alias pointing to your deployed ElasticSearch index
-  index_name: dpla_alias
+  index_name: {{ api_index_name }}
 
   # Name of your live river that points to your $index_name
   river_name: dpla_river

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -3,3 +3,7 @@
 # Linux kernel parameters
 kernel_vm_overcommit_memory: 0
 kernel_vm_overcommit_ratio: 90
+
+all_group_name: all
+
+resolver_domains: []

--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -13,3 +13,6 @@
 # sysctl.
 - name: start procps
   service: name=procps state=started
+
+- name: update resolv.conf
+  command: resolvconf -u

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -9,8 +9,19 @@
   tags:
     - kernel
 
+- name: Update hostname resolver configuration
+  template:
+    src: etc_resolvconf_resolv.conf.d_base.j2
+    dest: /etc/resolvconf/resolv.conf.d/base
+    mode: 0644
+    owner: root
+    group: root
+  notify: update resolv.conf
+
+- meta: flush_handlers
+
 - name: Set hostname
-  hostname: name={{ inventory_hostname }}
+  hostname: name={{ inventory_hostname | replace('_', '-') }}
   tags:
     - networking
 

--- a/ansible/roles/common/templates/etc_resolvconf_resolv.conf.d_base.j2
+++ b/ansible/roles/common/templates/etc_resolvconf_resolv.conf.d_base.j2
@@ -1,0 +1,3 @@
+{% for domain in resolver_domains %}
+search {{ domain }}
+{% endfor %}

--- a/ansible/roles/common/templates/hosts.j2
+++ b/ansible/roles/common/templates/hosts.j2
@@ -7,8 +7,11 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 
-{% for h in groups['all'] %}
-{{ hostvars[h][internal_network_interface]['ipv4']['address'] }}	{{ h }}
+{% for h in groups[all_group_name] %}
+{# Hostnames should not have underscores, but dynamic inventories (particularly,
+   EC2) can have names with underscores. They have to be converted to use
+   hyphens. #}
+{{ hostvars[h][internal_network_interface]['ipv4']['address'] }}	{{ h | replace('_', '-')}}
 {% endfor %}
 
 {% if level is defined and level == 'development' %}
@@ -22,7 +25,9 @@ ff02::2 ip6-allrouters
 {# TODO:  remove the "is defined" clause below once we get rid of the legacy #}
 {#        ingestion inventory and 'marmotta' is present in the #}
 {#        'development' inventory. #}
-{% if marmotta_domain is defined and inventory_hostname != 'central' and groups['marmotta'] is defined %}
+{% if marmotta_domain | default(false)
+   and inventory_hostname != 'central'
+   and groups['marmotta'] is defined %}
 {# assume one Marmotta host: #}
 {% set marmottahost = groups['marmotta'][0] %}
 {{ hostvars[marmottahost][internal_network_interface]['ipv4']['address'] }} {{ marmotta_domain }}

--- a/ansible/roles/common/templates/munin-node.conf.j2
+++ b/ansible/roles/common/templates/munin-node.conf.j2
@@ -46,7 +46,7 @@ ignore_file \.pod$
 # cidr_allow 192.0.2.0/24
 # cidr_deny  192.0.2.42/32
 
-{% if level == 'development' %}
+{% if level is defined and level == 'development' %}
 cidr_allow 192.168.50.0/24
 {% else %}
 cidr_allow {{ munin_master_ipaddr }}/32

--- a/ansible/roles/common_web/tasks/main.yml
+++ b/ansible/roles/common_web/tasks/main.yml
@@ -31,15 +31,7 @@
     - nginx
     - web
 
-- name: Copy Nginx settings for Nagios checks
-  copy: >
-      src=etc_nginx_conf.d_nagioschecks dest=/etc/nginx/conf.d/nagioschecks
-      owner=root group=root mode=0644
-  notify: restart nginx
-  tags:
-    - nginx
-    - web
-    - nagios
+# TODO before committing: git rm files/etc_nginx_conf.d_nagioschecks
 
 - name: Ensure "dpla" user exists
   user: >

--- a/ansible/roles/elasticsearch_index/defaults/main.yml
+++ b/ansible/roles/elasticsearch_index/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+create_alias: false
+alias_name: dpla_alias

--- a/ansible/roles/elasticsearch_index/tasks/main.yml
+++ b/ansible/roles/elasticsearch_index/tasks/main.yml
@@ -1,0 +1,87 @@
+---
+
+# elasticsearch_index role
+# ---
+#
+# These tasks are all run locally, from the system running Ansible.
+# This role can be run for a particular server by calling it from a playbook
+# where `hosts' is an inventory group, or can be run for the whole inventory
+# by calling it from a playbook where `hosts' is simply localhost and variables
+# are overridden to assign `es_cluster_loadbal'.
+
+# NOTE that the variable `index_name' is purposely undefined within this role.
+# You are expected to define it in the role invocation, or in a variable
+# declaration in your playbook, or on the commandline.
+
+# Example of running this role for the whole inventory, where the search index
+# is not used for one particular server:
+
+# - hosts: localhost
+#   vars:
+#     index_name: prod_20160605
+#   roles:
+#     - {role: elasticsearch_index }
+
+# Example of running this role for some kind of staging / test environment,
+# where you want each server to have its own search index:
+
+# - hosts: testinggroup
+#   roles:
+#     - {role: elasticsearch_index,
+#        index_name: "{{ inventory_hostname }}"}
+
+# TODO: add variable to govern whether to create an alias for the new index.
+
+- name: Check whether the index exists
+  become: no
+  local_action: uri
+  args:
+    url: "http://{{ es_cluster_loadbal }}/{{ index_name }}"
+    method: "HEAD"
+    status_code: "200,404"
+  register: probe
+
+- name: Display search index that will be created or updated
+  debug:
+    msg: "Search index: http://{{ es_cluster_loadbal }}/{{ index_name }}"
+
+# We would ideally create the index and post its settings and mappings in
+# the same request, but the serialization sorts the 'settings' and
+# 'mappings' properties alphabetically, and Elasticsearch 0.90 doesn't like
+# it if the mappings appear in the request body before the settings that
+# define analyzers and filters.
+
+- name: Create index
+  when: probe.status == 404
+  become: no
+  local_action: >-
+    command curl -X POST -i -d '{{ es_index_settings | to_json }}'
+    -H 'Content-Type: application/json'
+    "http://{{ es_cluster_loadbal }}/{{ index_name }}"
+  register: curl_post
+  failed_when: "'200 OK' not in curl_post.stdout"
+
+- name: Create or update mapping (item)
+  become: no
+  local_action: >-
+    command curl -X PUT -i -d '{{ es_index_mapping_item | to_json }}'
+    -H 'Content-Type: application/json'
+    "http://{{ es_cluster_loadbal }}/{{ index_name }}/item/_mapping"
+  register: curl_post
+  failed_when: "'200 OK' not in curl_post.stdout"
+
+- name: Create or update mapping (collection)
+  become: no
+  local_action: >-
+    command curl -X PUT -i -d '{{ es_index_mapping_collection | to_json }}'
+    -H 'Content-Type: application/json'
+    "http://{{ es_cluster_loadbal }}/{{ index_name }}/collection/_mapping"
+  register: curl_post
+  failed_when: "'200 OK' not in curl_post.stdout"
+
+# TODO: Create alias. This should be implemented with a module.
+#       We should check to see if the alias already exists and use
+#       the "remove" and "add" actions described in
+#       https://www.elastic.co/guide/en/elasticsearch/reference/0.90/indices-aliases.html
+#       to atomically reassign the alias if that's necessary.
+

--- a/ansible/roles/elasticsearch_index/vars/main.yml
+++ b/ansible/roles/elasticsearch_index/vars/main.yml
@@ -1,0 +1,555 @@
+---
+
+es_index_settings:
+
+  settings:
+    analysis:
+      analyzer:
+        canonical_sort:
+          type: custom
+          tokenizer: keyword
+          filter:
+            - lowercase
+            - pattern_replace
+      filter:
+        pattern_replace:
+          type: pattern_replace
+          pattern: >-
+            ^([^a-z0-9]+|a\b|an\b|the\b)*
+          replacement: ""
+
+es_index_mapping_collection:
+  collection:
+    date_detection: false
+    properties:
+      '@context':
+        type: "string"
+      '@id':
+        type: "string"
+        index: "not_analyzed"
+        norms:
+          enabled: false
+        index_options: "docs"
+      '@type':
+        type: "string"
+      _rev:
+        type: "object"
+        enabled: false
+      admin:
+        properties:
+          ingestDate:
+            type: "date"
+            format: "dateOptionalTime"
+          ingestType:
+            type: "object"
+            enabled: false
+          valid_after_enrich:
+            type: "boolean"
+          validation_message:
+            type: "object"
+            enabled: false
+      description:
+        type: "string"
+      id:
+        type: "string"
+        index: "not_analyzed"
+        norms:
+          enabled: false
+        index_options: "docs"
+      ingestDate:
+        type: "object"
+        enabled: false
+      ingestType:
+        type: "object"
+        enabled: false
+      ingestionSequence:
+        type: "long"
+      title:
+        type: "multi_field"
+        fields:
+          title:
+            type: "string"
+          not_analyzed:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+            include_in_all: false
+
+es_index_mapping_item:
+  item:
+    date_detection: false
+    properties:
+      '@context':
+        type: "object"
+        enabled: false
+      '@id':
+        type: "string"
+        index: "not_analyzed"
+        norms:
+          enabled: false
+        index_options: "docs"
+      '@type':
+        type: "string"
+      _rev:
+        type: "object"
+        enabled: false
+      admin:
+        properties:
+          contributingInstitution:
+            type: "string"
+            include_in_all: false
+          ingestDate:
+            type: "date"
+            format: "dateOptionalTime"
+          ingestType:
+            type: "object"
+            enabled: false
+          object_status:
+            type: "long"
+          sourceResource:
+            properties:
+              title:
+                type: "string"
+                analyzer: "canonical_sort"
+                null_value: "zzzzzzzz"
+          valid_after_enrich:
+            type: "boolean"
+          validation_message:
+            type: "object"
+            enabled: false
+      aggregatedCHO:
+        type: "string"
+      dataProvider:
+        type: "multi_field"
+        fields:
+          dataProvider:
+            type: "string"
+          not_analyzed:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+            include_in_all: false
+      hasView:
+        properties:
+          '@id':
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+          edmRights:
+            type: "multi_field"
+            fields:
+              edmRights:
+                type: "string"
+              not_analyzed:
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+                include_in_all: false
+          format:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+          rights:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+      id:
+        type: "string"
+        index: "not_analyzed"
+        norms:
+          enabled: false
+        index_options: "docs"
+      ingestDate:
+        type: "object"
+        enabled: false
+      ingestType:
+        type: "object"
+        enabled: false
+      ingestionSequence:
+        type: "long"
+      intermediateProvider:
+        type: "multi_field"
+        fields:
+          intermediateProvider:
+            type: "string"
+          not_analyzed:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+            include_in_all: false
+      isPartOf:
+        properties:
+          '@id':
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+          name:
+            type: "multi_field"
+            fields:
+              name:
+                type: "string"
+              not_analyzed:
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+                include_in_all: false
+      isShownAt:
+        type: "string"
+        index: "not_analyzed"
+        norms:
+          enabled: false
+        index_options: "docs"
+      object:
+        type: "string"
+        index: "not_analyzed"
+        norms:
+          enabled: false
+        index_options: "docs"
+      originalRecord:
+        type: "object"
+        enabled: false
+      provider:
+        properties:
+          '@id':
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+          name:
+            type: "multi_field"
+            fields:
+              name:
+                type: "string"
+              not_analyzed:
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+                include_in_all: false
+      rights:
+        type: "string"
+      sourceResource:
+        properties:
+          '@id':
+            type: "string"
+          collection:
+            properties:
+              '@id':
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+              description:
+                type: "string"
+              id:
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+              title:
+                type: "multi_field"
+                fields:
+                  title:
+                    type: "string"
+                  not_analyzed:
+                    type: "string"
+                    index: "not_analyzed"
+                    norms:
+                      enabled: false
+                    index_options: "docs"
+                    include_in_all: false
+          contributor:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+          creator:
+            type: "string"
+          date:
+            properties:
+              begin:
+                type: "multi_field"
+                fields:
+                  begin:
+                    type: "date"
+                    ignore_malformed: true
+                    format: "dateOptionalTime"
+                    null_value: "-9999"
+                  not_analyzed:
+                    type: "date"
+                    ignore_malformed: true
+                    format: "dateOptionalTime"
+                    include_in_all: false
+              displayDate:
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+              end:
+                type: "multi_field"
+                fields:
+                  end:
+                    type: "date"
+                    ignore_malformed: true
+                    format: "dateOptionalTime"
+                    null_value: "9999"
+                  not_analyzed:
+                    type: "date"
+                    ignore_malformed: true
+                    format: "dateOptionalTime"
+                    include_in_all: false
+          description:
+            type: "string"
+          extent:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+          format:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+          genre:
+            type: "string"
+          identifier:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+          isPartOf:
+            type: "object"
+            enabled: false
+          language:
+            properties:
+              iso639_3:
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+              name:
+                type: "multi_field"
+                fields:
+                  name:
+                    type: "string"
+                  not_analyzed:
+                    type: "string"
+                    index: "not_analyzed"
+                    norms:
+                      enabled: false
+                    index_options: "docs"
+                    include_in_all: false
+          publisher:
+            type: "multi_field"
+            fields:
+              publisher:
+                type: "string"
+              not_analyzed:
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+                include_in_all: false
+          relation:
+            type: "string"
+          rights:
+            type: "string"
+          spatial:
+            properties:
+              city:
+                type: "multi_field"
+                fields:
+                  city:
+                    type: "string"
+                  not_analyzed:
+                    type: "string"
+                    index: "not_analyzed"
+                    norms:
+                      enabled: false
+                    index_options: "docs"
+                    include_in_all: false
+              coordinates:
+                type: "geo_point"
+              country:
+                type: "multi_field"
+                fields:
+                  country:
+                    type: "string"
+                  not_analyzed:
+                    type: "string"
+                    index: "not_analyzed"
+                    norms:
+                      enabled: false
+                    index_options: "docs"
+                    include_in_all: false
+              county:
+                type: "multi_field"
+                fields:
+                  county:
+                    type: "string"
+                  not_analyzed:
+                    type: "string"
+                    index: "not_analyzed"
+                    norms:
+                      enabled: false
+                    index_options: "docs"
+                    include_in_all: false
+              iso3166-2:
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+              name:
+                type: "multi_field"
+                fields:
+                  name:
+                    type: "string"
+                  not_analyzed:
+                    type: "string"
+                    index: "not_analyzed"
+                    norms:
+                      enabled: false
+                    index_options: "docs"
+                    include_in_all: false
+              region:
+                type: "multi_field"
+                fields:
+                  region:
+                    type: "string"
+                  not_analyzed:
+                    type: "string"
+                    index: "not_analyzed"
+                    norms:
+                      enabled: false
+                    index_options: "docs"
+                    include_in_all: false
+              state:
+                type: "multi_field"
+                fields:
+                  state:
+                    type: "string"
+                  not_analyzed:
+                    type: "string"
+                    index: "not_analyzed"
+                    norms:
+                      enabled: false
+                    index_options: "docs"
+                    include_in_all: false
+          specType:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"
+          stateLocatedIn:
+            properties:
+              iso3166-2:
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+              name:
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+          subject:
+            properties:
+              '@id':
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+              '@type':
+                type: "string"
+                index: "not_analyzed"
+                norms:
+                  enabled: false
+                index_options: "docs"
+              name:
+                type: "multi_field"
+                fields:
+                  name:
+                    type: "string"
+                  not_analyzed:
+                    type: "string"
+                    index: "not_analyzed"
+                    norms:
+                      enabled: false
+                    index_options: "docs"
+                    include_in_all: false
+          temporal:
+            properties:
+              '#text':
+                type: "string"
+              begin:
+                type: "multi_field"
+                fields:
+                  begin:
+                    type: "date"
+                    ignore_malformed: true
+                    format: "dateOptionalTime"
+                    null_value: "-9999"
+                  not_analyzed:
+                    type: "date"
+                    ignore_malformed: true
+                    format: "dateOptionalTime"
+                    include_in_all: false
+              displayDate:
+                type: "string"
+              encoding:
+                type: "string"
+              end:
+                type: "multi_field"
+                fields:
+                  end:
+                    type: "date"
+                    ignore_malformed: true
+                    format: "dateOptionalTime"
+                    null_value: "9999"
+                  not_analyzed:
+                    type: "date"
+                    ignore_malformed: true
+                    format: "dateOptionalTime"
+                    include_in_all: false
+          title:
+            type: "string"
+          type:
+            type: "string"
+            index: "not_analyzed"
+            norms:
+              enabled: false
+            index_options: "docs"

--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -11,7 +11,8 @@
     - libmagickwand-dev
     - libreadline6
     - libreadline6-dev
-  when: not skip_configuration
+    - g++
+  when: not skip_configuration | default(false)
   tags:
     - packages
 
@@ -28,7 +29,7 @@
   template: >
       src=etc_init.d_unicorn_frontend.j2 dest=/etc/init.d/unicorn_frontend
       owner=root group=root mode=0755
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - web
     - initscripts
@@ -37,7 +38,7 @@
   template: >
       src=start_unicorn_frontend.sh.j2 dest=/usr/local/sbin/start_unicorn_frontend.sh
       owner=root group=root mode=0755
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - web
     - scripts
@@ -45,7 +46,7 @@
 
 - name: Ensure that Unicorn init script starts and stops on boot/shutdown
   command: update-rc.d unicorn_frontend defaults
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - web
     - initscripts
@@ -56,7 +57,7 @@
       dest="/etc/nginx/sites-available/frontend"
       owner=root group=root mode=0644
   notify: restart nginx
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - nginx
     - web
@@ -67,7 +68,7 @@
       dest="/etc/nginx/sites-enabled/frontend"
       state=link owner=root group=root
   notify: restart nginx
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - nginx
     - web
@@ -77,7 +78,7 @@
       src=etc_logrotate.d_frontend_rails_logs.j2
       dest=/etc/logrotate.d/frontend_rails_logs
       owner=root group=root mode=0644
-  when: not skip_configuration
+  when: not skip_configuration | default(false)
   tags:
     - web
     - logrotate

--- a/ansible/roles/postgresql/templates/pg_hba.conf.j2
+++ b/ansible/roles/postgresql/templates/pg_hba.conf.j2
@@ -72,18 +72,19 @@
 # listen on a non-local interface via the listen_addresses
 # configuration parameter, or via the -i or -h command line switches.
 
+# hostvars[h][internal_network_interface]['ipv4']['address']
 
 {% for host in groups['frontend'] %}
-host   all             all            {{ host }}             md5
+host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 {% for host in groups['api'] %}
-host   all             all            {{ host }}             md5
+host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 
 {# The `cms` group needs access because of the pss app #}
 {% if groups['cms'] is defined %}
 {% for host in groups['cms'] %}
-host   all             all            {{ host }}             md5
+host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 {% endif %}
 
@@ -93,19 +94,19 @@ host   all             all            {{ host }}             md5
 
 {% if groups['ingestion_app'] is defined %}
 {% for host in groups['ingestion_app'] %}
-host   all             all            {{ host }}             md5
+host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 {% endif %}
 
 {% if groups['worker'] is defined %}
 {% for host in groups['worker'] %}
-host   all             all            {{ host }}             md5
+host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 {% endif %}
 
 {% if groups['marmotta'] is defined %}
 {% for host in groups['marmotta'] %}
-host   all             all            {{ host }}             md5
+host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
* Add elasticsearch_index role. This will be incorporated into the development playbooks at a later point.
* Update some variables to default to False when they're not defined.
* Parameterize some configuration file parameters.
* Change common role to observe `all_group_name` for more flexibility with custom environments.
* Update common role to work better in dynamic inventory situations.
* Update postgresql role to use IP addresses instead of hostnames, for simplicity, and to avoid having to convert characters in dynamic-inventory hostnames.
* Tidy up various minor things.