### PR TITLE
Clean up MOTDs, remove demo packages

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -66,6 +66,12 @@
     - puppet-common
     - chef
     - chef-zero
+    - landscape-common
+    - landscape-client
+
+- name: Remove Ubuntu Advantage Cloud Guest advertisement
+  file: >
+    path="/etc/update-motd.d/51-cloudguest" state=absent
 
 - name: Disable default munin plugins that we don't need
   file: >


### PR DESCRIPTION
Remove Landscape demo packages and Ubuntu Advantage Cloud guest advertisement, both of which clutter our MOTDs.

This is not high-priority, but fixes a longstanding minor annoyance.
