### PR TITLE
Stop clearing NGINX proxy cache unnecessarily

### DIFF
--- a/ansible/roles/api/tasks/deploy.yml
+++ b/ansible/roles/api/tasks/deploy.yml
@@ -74,10 +74,5 @@
   notify:
     - restart memcached
 
-- name: Clear site proxy cache
-  command: find /var/cache/nginx -type f -delete
-  delegate_to: "{{ item }}"
-  with_items: groups.site_proxies
-
 - name: Start Unicorn
   service: name=unicorn_api state=started

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -101,11 +101,6 @@
       path=/srv/www/frontend/public/uploads state=directory
       owner=dpla group=dpla mode=0755 recurse=yes
 
-- name: Clear site proxy cache
-  command: find /var/cache/nginx -type f -delete
-  delegate_to: "{{ item }}"
-  with_items: groups.site_proxies
-
 - name: Start Unicorn
   service: name=unicorn_frontend state=started
 

--- a/ansible/roles/omeka/defaults/main.yml
+++ b/ansible/roles/omeka/defaults/main.yml
@@ -10,5 +10,3 @@ omeka_php_start_servers: 2
 omeka_php_min_spare_servers: 2
 omeka_php_max_spare_servers: 4
 omeka_php_max_requests: 500
-
-skip_site_proxy_cache: false

--- a/ansible/roles/omeka/tasks/deploy.yml
+++ b/ansible/roles/omeka/tasks/deploy.yml
@@ -76,9 +76,3 @@
     - square_thumbnails
     - theme_uploads
     - thumbnails
-
-- name: Clear site proxy cache
-  command: find /var/cache/nginx -type f -delete
-  delegate_to: "{{ item }}"
-  with_items: groups.site_proxies
-  when: not skip_site_proxy_cache

--- a/ansible/roles/pss/tasks/deploy.yml
+++ b/ansible/roles/pss/tasks/deploy.yml
@@ -108,11 +108,6 @@
       path=/srv/www/pss/public/uploads state=directory
       owner=dpla group=dpla mode=0755 recurse=yes
 
-- name: Clear site proxy cache
-  command: find /var/cache/nginx -type f -delete
-  delegate_to: "{{ item }}"
-  with_items: groups.site_proxies
-
 - name: Start Unicorn
   service: name=unicorn_pss state=started
 

--- a/ansible/roles/wordpress/handlers/main.yml
+++ b/ansible/roles/wordpress/handlers/main.yml
@@ -5,8 +5,3 @@
 
 - name: reload php5-fpm
   service: name=php5-fpm state=reloaded
-
-- name: clear site proxy cache
-  command: find /var/cache/nginx -type f -delete
-  delegate_to: "{{ item }}"
-  with_items: groups.site_proxies

--- a/ansible/roles/wordpress/tasks/main.yml
+++ b/ansible/roles/wordpress/tasks/main.yml
@@ -41,7 +41,6 @@
   become_user: dpla
   when: do_wordpress and do_deployment
   notify:
-    - clear site proxy cache
     - reload php5-fpm
   tags:
     - web
@@ -61,7 +60,6 @@
   when: do_wordpress and do_deployment
   notify:
     - reload php5-fpm
-    - clear site proxy cache
   tags:
     - web
 
@@ -83,7 +81,6 @@
       owner=root group=root mode=0644
   notify:
     - restart nginx
-    - clear site proxy cache
   when: do_wordpress and not skip_configuration
   tags:
     - nginx
@@ -96,7 +93,6 @@
       state=link owner=root group=root
   notify:
     - restart nginx
-    - clear site proxy cache
   when: do_wordpress and not skip_configuration
   tags:
     - nginx


### PR DESCRIPTION
The NGINX cache configuration was changed in [v3.3.0](https://github.com/dpla/automation/releases/tag/v3.3.0) to make it safer for the cache to hold on to assets for a longer time. Pages that have to be fresh are no longer cached. We can therefore remove the role tasks that used to clear the cache. We still clear the Memcache cache where necessary, and we still have the playbook for doing it manually.

Addresses https://issues.dp.la/issues/8157

This could be something to try with one of your next deployments to verify how it goes.
