### PR TITLE
Install geocoder config for ingestion

### DIFF
--- a/ansible/roles/ingestion_app/defaults/main.yml
+++ b/ansible/roles/ingestion_app/defaults/main.yml
@@ -8,6 +8,19 @@ heidrun_mappings_branch_or_tag: master
 heidrun_mappings_repo: dpla/heidrun-mappings
 ingestion_app_rails_env: development
 ingestion_app_alternate_db_host: false
+# ingestion_app_geo_dist_thresh: The value of distance_threshold in geocoder.yml
+ingestion_app_geo_dist_thresh: 100
+# ingestion_app_geo_maxint: The value of max_interpretations in geocoder.yml
+ingestion_app_geo_maxint: 5
+# ingestion_app_geo_host is for cases where there is no 'geocoder' inventory
+# group; where the geocoder server is not reflected in our inventory. This
+# should be overridden in that case.
+ingestion_app_geo_host: notconfigured
+# ingestion_app_geo_timeout: The twofishes_timeout value in geocoder.yml
+ingestion_app_geo_timeout: 10
+# ingestion_app_geo_retries: The twofishes_retries value in geocoder.yml
+ingestion_app_geo_retries: 2
+
 ingestion_app_log_level: debug
 
 ingestion_secret_key_base: 227577a6f5b650eee5e30d2519872b0163a4b3112449ff4876cf9b5d7bf3edae86935d7dea2b59466ea435617116f9c2dafa6fa19e078e05017693a2a330cebc

--- a/ansible/roles/ingestion_app/tasks/deploy.yml
+++ b/ansible/roles/ingestion_app/tasks/deploy.yml
@@ -165,6 +165,14 @@
     dest=/home/dpla/heidrun/config/solr.yml
     owner=dpla group=dpla mode=0644
 
+- name: Update geocode.yml file in ingestion app
+  template:
+    src: geocode.yml.j2
+    dest: /home/dpla/heidrun/geocode.yml
+    owner: dpla
+    group: dpla
+    mode: 0644
+
 - name: Update configuration for test environment
   # On overriding settings:  https://github.com/railsconfig/rails_config#common-config-file
   template: >-

--- a/ansible/roles/ingestion_app/templates/geocode.yml.j2
+++ b/ansible/roles/ingestion_app/templates/geocode.yml.j2
@@ -1,0 +1,13 @@
+---
+
+distance_threshold: {{ ingestion_app_geo_dist_thresh }}
+max_intepretations: {{ ingestion_app_geo_maxint }}
+{% if 'geocoder' in groups %}
+{%     set geohost = groups['geocoder'] | first %}
+{% else %}
+{%     set geohost = ingestion_app_geo_host %}
+{% endif %}
+twofishes_host: {{ geohost }}
+twofishes_port: 8080
+twofishes_timeout: {{ ingestion_app_geo_timeout }}
+twofishes_retries: {{ ingestion_app_geo_retries }}


### PR DESCRIPTION
Install the geocoder.yml configuration file that is needed by the Audumbla gem for enrichments in the ingestion application.

The installed configuration will not work in a development environment until the developer sets the `ingestion_app_geo_host` variable to something suitable (for example, in the `ansible/group_vars/development` file). The Twofishes geocoding server is not installed into the development VMs and must be managed separately.

Fixes https://issues.dp.la/issues/8455