### PR TITLE
Check for errors in more build script locations

### DIFF
--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -43,7 +43,7 @@ fi
 rbenv rehash
 
 echo "precompiling assets ..." >> $LOGFILE
-bundle exec rake assets:precompile >> $LOGFILE 2>&1
+bundle exec rake assets:precompile >> $LOGFILE 2>&1 || exit 1
 
 if [ "$BRANDING" == "branding" ]; then
     echo "killing ssh_agent ..." >> $LOGFILE
@@ -64,7 +64,8 @@ fi
 
 echo "migrate database ..." >> $LOGFILE
 cd /srv/www/frontend
-bundle exec rake db:migrate
+bundle exec rake db:migrate || exit 1
+
 
 echo "check logfile directory ..." >> $LOGFILE
 
@@ -73,4 +74,7 @@ if [ ! -d $logdir ]; then
     mkdir $logdir \
         && chown dpla:webapp $logdir \
         && chmod 0775 $logdir
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
 fi

--- a/ansible/roles/ingestion_app/files/build_ingestion.sh
+++ b/ansible/roles/ingestion_app/files/build_ingestion.sh
@@ -76,9 +76,13 @@ echo "checking directories ... " >> $LOGFILE
 dirs_to_check='/opt/heidrun/log /opt/heidrun/tmp'
 for dir in $dirs_to_check; do
     if [ ! -d $dir ]; then
+        echo "... creating $dir"
         mkdir $dir \
             && chown dpla:webapp $dir \
             && chmod 0775 $dir
+        if [ $? -ne 0 ]; then
+            exit 1
+        fi
     fi
 done
 

--- a/ansible/roles/pss/files/build_pss.sh
+++ b/ansible/roles/pss/files/build_pss.sh
@@ -31,7 +31,7 @@ fi
 rbenv rehash >> $LOGFILE 2>&1
 
 echo "precompiling assets ..." >> $LOGFILE
-bundle exec rake assets:precompile >> $LOGFILE 2>&1
+bundle exec rake assets:precompile >> $LOGFILE 2>&1 || exit 1
 
 if [ "$BRANDING" == "branding" ]; then
     echo "killing ssh_agent ..." >> $LOGFILE
@@ -55,4 +55,4 @@ cd /srv/www/pss
 
 echo "migrate database ..." >> $LOGFILE
 cd /srv/www/pss
-bundle exec rake db:migrate >> $LOGFILE 2>&1
+bundle exec rake db:migrate >> $LOGFILE 2>&1 || exit 1


### PR DESCRIPTION
Add checks for return statuses in more of the commands issued in Rails deployment scripts.  There were rake tasks and other commands that could have failed silently and could have allowed deployments to proceed incorrectly.