### PR TITLE
Fix thumbp pidfile location

### DIFF
--- a/ansible/roles/thumbp/tasks/main.yml
+++ b/ansible/roles/thumbp/tasks/main.yml
@@ -16,9 +16,6 @@
 - name: Ensure state of log directory
   file: path=/var/log/thumbp state=directory owner=thumbp mode=0755
 
-- name: Ensure state of pid directory
-  file: path=/var/run/thumbp state=directory owner=thumbp mode=0755
-
 - name: Ensure state of opt directory
   file: path=/opt/thumbp state=directory owner=thumbp mode=0755
 

--- a/ansible/roles/thumbp/templates/etc_init.d_thumbp.j2
+++ b/ansible/roles/thumbp/templates/etc_init.d_thumbp.j2
@@ -21,7 +21,7 @@ export LANG
 export NVM_DIR=/opt/thumbp/.nvm
 
 THUMBP_ROOT=/opt/thumbp/thumbp
-PIDFILE=/var/run/thumbp/thumbp.pid
+PIDFILE=/var/run/thumbp.pid
 LOGDIR=/var/log/thumbp
 USER=thumbp
 ES_BASE=http://{{ es_cluster_loadbal }}/dpla_alias/item


### PR DESCRIPTION
Instead of creating a subdirectory of `/var/run` that will get wiped out upon reboot, just put the pidfile in `/var/run` as other programs do.