### PR TITLE
Add missing do_deployment var to thumbp playbook

### DIFF
--- a/ansible/playbooks/thumbp.yml
+++ b/ansible/playbooks/thumbp.yml
@@ -7,5 +7,7 @@
   hosts: thumbp
   serial: 1
   become: yes
+  vars:
+    do_deployment: yes
   roles:
     - thumbp


### PR DESCRIPTION
Add the `do_deployment` variable to the `thumbp.yml` playbook.

This variable is evaluated by a number of roles, where it has no default by design. It was missing from the `thumbp` playbook, causing an error.
