### PR TITLE
Remove ipv6 listen from site_proxy NGINX config

### DIFF
--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -156,7 +156,6 @@ upstream dpla_thumbp {
 server {
 
     listen   {{ siteproxy_port }} default;
-    listen   [::]:{{ siteproxy_port }} default ipv6only=on;
 
     server_name {{ frontend_hostname }};
   


### PR DESCRIPTION
Remove ipv6 listen directive from the site_proxy role's NGINX configuration. There is a loadbalancer in front of the site proxy under normal conditions, and it uses the siteproxy server's ipv4 address.
