### PR TITLE
Add Tomcat and Marmotta features for profiling and custom packages

### DIFF
--- a/ansible/roles/marmotta/defaults/main.yml
+++ b/ansible/roles/marmotta/defaults/main.yml
@@ -5,3 +5,5 @@ marmotta_heidrun_allowed_ip:  192.168.50.0/24
 marmotta_home: /var/lib/marmotta
 marmotta_version: 3.3.0
 marmotta_tomcat_open_files_limit: 10240
+marmotta_archive_base_url: "http://www-us.apache.org/dist/marmotta/{{ marmotta_version }}"
+marmotta_archive_checksum: 34c37281b6875ea95da391ae5bbe059f31091f3c6bf2529539241b35690c84b0

--- a/ansible/roles/marmotta/tasks/main.yml
+++ b/ansible/roles/marmotta/tasks/main.yml
@@ -30,9 +30,10 @@
 
 - name: "Download tar archive, if necessary"
   get_url:
-    url: "http://www-us.apache.org/dist/marmotta/{{ marmotta_version }}/apache-marmotta-{{ marmotta_version }}-webapp.tar.gz"
-    sha256sum: 34c37281b6875ea95da391ae5bbe059f31091f3c6bf2529539241b35690c84b0
+    url: "{{ marmotta_archive_base_url }}/apache-marmotta-{{ marmotta_version }}-webapp.tar.gz"
+    sha256sum: "{{ marmotta_archive_checksum }}"
     dest: "/tmp/apache-marmotta-{{ marmotta_version }}-webapp.tar.gz"
+    timeout: 120
   when: not warstat.stat.exists
 
 - name: "Unpack tar archive, if necessary"

--- a/ansible/roles/tomcat_common/defaults/main.yml
+++ b/ansible/roles/tomcat_common/defaults/main.yml
@@ -6,6 +6,8 @@ tomcat_munin_username: tcmunin
 tomcat_munin_password: changememunin
 tomcat_max_mem_mb: 256
 tomcat_init_mem_mb: 256
+# The JDK can be installed for development or debugging purposes:
+tomcat_install_jdk: no
 
 # logfile ages, in days:
 # ... "catalina" logs are rotated by logrotate:

--- a/ansible/roles/tomcat_common/defaults/main.yml
+++ b/ansible/roles/tomcat_common/defaults/main.yml
@@ -22,3 +22,6 @@ tomcat_accesslogvalve_log_age: 7
 # Kernel limit for the number of open files that the Tomcat jvm process should
 # be allowed to have open
 tomcat_open_files_limit: 10240
+
+# Whether to enable Java Management Extensions for profiling, etc.:
+tomcat_enable_jmx_extensions: no

--- a/ansible/roles/tomcat_common/tasks/main.yml
+++ b/ansible/roles/tomcat_common/tasks/main.yml
@@ -9,6 +9,10 @@
     mode: 0644
   notify: restart tomcat
 
+- name: "Install the Java JDK, if requested"
+  when: tomcat_install_jdk
+  apt: name=openjdk-7-jdk state=present
+
 - name: Make sure that the Tomcat packages are installed
   apt: name={{ item }} state=present
   with_items:

--- a/ansible/roles/tomcat_common/templates/etc_default_tomcat7.j2
+++ b/ansible/roles/tomcat_common/templates/etc_default_tomcat7.j2
@@ -24,6 +24,10 @@ JAVA_OPTS="-Djava.awt.headless=true -Xmx{{ tomcat_max_mem_mb }}m -Xms{{ tomcat_i
 # You will then be able to use a java debugger on port 8000.
 #JAVA_OPTS="${JAVA_OPTS} -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n"
 
+{% if tomcat_enable_jmx_extensions %}
+JAVA_OPTS="${JAVA_OPTS} -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=3000 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ inventory_hostname }}"
+{% endif %}
+
 # Java compiler to use for translating JavaServer Pages (JSPs). You can use all
 # compilers that are accepted by Ant's build.compiler property.
 #JSP_COMPILER=javac


### PR DESCRIPTION
- Add option to install Java JDK for the `tomcat` role. The JDK has tools for profiling.
- Optionally enable [JMX](https://en.wikipedia.org/wiki/Java_Management_Extensions) extensions for Tomcat's JVM
- Parameterize the Marmotta repository location and archive file checksum, so that it's possible to install your own build of Marmotta.

I think that these should be left as three commits.

Please don't merge this until we've confirmed that the `JAVA_OPTS` are adequate. I wanted to submit this for discussion first.

Note that the Tomcat changes are distinct from the Marmotta changes so that they can be applied to any Tomcat server in our infrastructure.
