### PR TITLE
Move Tomcat kernel limits task to tomcat_common role

### DIFF
--- a/ansible/roles/marmotta/templates/etc_security_limits.d_tomcat.conf.j2
+++ b/ansible/roles/marmotta/templates/etc_security_limits.d_tomcat.conf.j2
@@ -1,2 +1,0 @@
-tomcat7   soft    nofile    {{ marmotta_tomcat_open_files_limit }}
-tomcat7   hard    nofile    {{ marmotta_tomcat_open_files_limit }}

--- a/ansible/roles/tomcat_common/defaults/main.yml
+++ b/ansible/roles/tomcat_common/defaults/main.yml
@@ -16,3 +16,7 @@ tomcat_catalina_log_age: 7
 # pruned by our own cron job.  See etc_default_tomcat7.j2 and
 # etc_logrotate.d_tomcat7.j2.
 tomcat_accesslogvalve_log_age: 7
+
+# Kernel limit for the number of open files that the Tomcat jvm process should
+# be allowed to have open
+tomcat_open_files_limit: 10240

--- a/ansible/roles/tomcat_common/tasks/main.yml
+++ b/ansible/roles/tomcat_common/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Ensure sufficient kernel resource limits for the tomcat7 user
+  template:
+    src: etc_security_limits.d_tomcat.conf.j2
+    dest: /etc/security/limits.d/tomcat.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart tomcat
+
 - name: Make sure that the Tomcat packages are installed
   apt: name={{ item }} state=present
   with_items:

--- a/ansible/roles/tomcat_common/templates/etc_security_limits.d_tomcat.conf.j2
+++ b/ansible/roles/tomcat_common/templates/etc_security_limits.d_tomcat.conf.j2
@@ -1,0 +1,2 @@
+tomcat7   soft    nofile    {{ tomcat_open_files_limit }}
+tomcat7   hard    nofile    {{ tomcat_open_files_limit }}


### PR DESCRIPTION
Move the task and variables to set kernel limits for the Tomcat process out of the `marmotta` role and into the `tomcat_common` role.

To set specific limits, e.g. for Marmotta or another Java application, one should modify the `host_vars` file for the relevant server.
