### PR TITLE
Configure logfile rotation in common_web role

### DIFF
--- a/ansible/roles/common_web/defaults/main.yml
+++ b/ansible/roles/common_web/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 
 nginx_log_level: notice
+nginx_rotate_days: 14

--- a/ansible/roles/common_web/tasks/main.yml
+++ b/ansible/roles/common_web/tasks/main.yml
@@ -12,6 +12,18 @@
     - nginx
     - web
 
+- name: Make sure nginx logs get rotated
+  template:
+      src: etc_logrotate.d_nginx.j2
+      dest: /etc/logrotate.d/nginx
+      owner: root
+      group: root
+      mode: 0644
+  tags:
+    - logrotate
+    - nginx
+    - web
+
 - name: Ensure git is present
   apt: pkg=git state=present
   tags:

--- a/ansible/roles/common_web/templates/etc_logrotate.d_nginx.j2
+++ b/ansible/roles/common_web/templates/etc_logrotate.d_nginx.j2
@@ -1,7 +1,7 @@
 /var/log/nginx/*.log {
     daily
     missingok
-    rotate 7
+    rotate {{ nginx_rotate_days }}
     compress
     delaycompress
     notifempty

--- a/ansible/roles/marmotta/tasks/main.yml
+++ b/ansible/roles/marmotta/tasks/main.yml
@@ -78,13 +78,6 @@
   tags:
     - nginx
 
-- name: Make sure nginx logs get rotated
-  template: >-
-      src="etc_logrotate.d_nginx.j2" dest="/etc/logrotate.d/nginx"
-      owner=root group=root mode=0644
-  tags:
-    - logrotate
-
 - name: Symlink webserver virtual host for Marmotta
   file: >-
       src="/etc/nginx/sites-available/marmotta"


### PR DESCRIPTION
Add a task to configure logrotate for the NGINX logs, with a variable to govern the rotation period.

Remove the logfile rotation task and template from the Marmotta role.

Note that if different hosts need specific log rotation periods, they can be configured in host_vars files.
