### PR TITLE
Add more kernel param vars to dev2 in inventory

### DIFF
--- a/ansible/ingestion
+++ b/ansible/ingestion
@@ -1,5 +1,5 @@
 dev1 ansible_ssh_host=192.168.50.7
-dev2 ansible_ssh_host=192.168.50.8 tomcat_max_mem_mb=256 tomcat_init_mem_mb=256 kernel_vm_overcommit_ratio=95
+dev2 ansible_ssh_host=192.168.50.8 tomcat_max_mem_mb=256 tomcat_init_mem_mb=256 kernel_vm_overcommit_ratio=95 kernel_shmmax=4080218931 kernel_shmall=1022361
 
 [loadbalancer]
 dev1


### PR DESCRIPTION
I've had this change sitting around for a while without committing it. It has worked fine with my VMs (where I had them in a `host_vars` file, but the effect should be the same).
