### PR TITLE
added location alias for siteproxy.xml

### DIFF
--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -263,6 +263,10 @@ server {
             alias /srv/www/robots.txt;
         }
 
+        location /sitemap.xml {
+            alias /srv/www/sitemap.xml;
+        }
+
         location /assets {
             # FIXME:
             # It would be great to extend the expiration of frontend assets,


### PR DESCRIPTION
Just a quick addition to the nginx config to make the root sitemap available at the root of our site for testing Google Webmaster Tools against.
