### PR TITLE
Lower defult NGINX cache size

### DIFF
--- a/ansible/roles/site_proxy/defaults/main.yml
+++ b/ansible/roles/site_proxy/defaults/main.yml
@@ -39,7 +39,7 @@ siteproxy_nginx_limit_conn_log_level: notice
 siteproxy_nginx_limit_req_log_level: notice
 
 # Maximum disk space used by the NGINX cache. Our default is 6 Gb.
-siteproxy_nginx_cache_max_size: 6144m
+siteproxy_nginx_cache_max_size: 5120m
 # Size of shared memory zone that is used for NGINX cache
 siteproxy_nginx_cache_shmem_size: 360m
 # How long an item can remain in the cache without being accessed, independently


### PR DESCRIPTION
Lower the default size of the NGINX disk cache for the site_proxy role from 6Gb to 5Gb. This role is likely to be deployed on AWS, where the default volume size is 8Gb, so 6Gb is not leaving a lot of room for other things on the filesystem.
