### PR TITLE
add configuration for pss x-frame-options

### DIFF
--- a/ansible/roles/pss/defaults/main.yml
+++ b/ansible/roles/pss/defaults/main.yml
@@ -32,3 +32,4 @@ pss_include_branding: false
 pss_delivery_method: file
 pss_api_key: aa11d0958e93bb25e457a726dc10a40f
 pss_api_url: "//{{ api_hostname }}:{{ api_port }}"
+pss_x_frame_options: 'SAMEORIGIN'

--- a/ansible/roles/pss/templates/settings.local.yml.j2
+++ b/ansible/roles/pss/templates/settings.local.yml.j2
@@ -59,3 +59,6 @@ cache:
     - {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}
 {% endfor %}
     - { namespace: 'pss' }
+
+http_headers:
+  x_frame_options: {{ pss_x_frame_options }}


### PR DESCRIPTION
This allows us to set X-Frame-Options for primary source sets.  Along with accompanying changes to [pss](https://github.com/dpla/primary-source-sets/pull/179) and [aws](https://github.com/dpla/aws/pull/47), it will allow OER commons to display an iframe of primary source sets.  OER commons indexes our sets in their educational resources discovery tool.

I have run a local deployment, and verified with curl. This addresses [ticket #8490](https://issues.dp.la/issues/8490).