### PR TITLE
remove un-needed setting for frontend exibitions elasticsearch

### DIFF
--- a/ansible/roles/frontend/templates/settings.local.yml.j2
+++ b/ansible/roles/frontend/templates/settings.local.yml.j2
@@ -16,6 +16,8 @@ exhibitions:
   # Omeka exhibition site address. Used for generating link
   site: //{{ frontend_hostname }}/exhibitions
   # Elasticsearch instance for searching exhibitions
+  # These settings are obsolete for frontend > v21.4.1
+  # In future versions of automation, they may be unsupported
   elasticsearch:
     host: http://ignore-me:9200
     default_index: omeka


### PR DESCRIPTION
Remove un-needed frontend setting related to searching for exhibitions in elasticsearch.

This addresses [ticket #7579](https://issues.dp.la/issues/7579) and relates to [frontend PR#131](https://github.com/dpla/frontend/pull/131).