### PR TITLE
Add sequence nums to update-rc.d for delayed_job

### DIFF
--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -98,7 +98,7 @@
 
 - name: Set delayed_job runlevels if contentqa is selected
   when: api_enable_contentqa
-  command: update-rc.d delayed_job_api defaults
+  command: update-rc.d delayed_job_api defaults 22 17
   tags:
     - web
     - initscripts


### PR DESCRIPTION
Add sequence number parameters to the `update-rc.d` command that is called in order to make symbolic links for `delayed_job`'s init script. This makes it explicit that it should start after PostgreSQL. Just to give the other daemons some breathing room and to hopefully aid troubleshooting, I've also caused delayed_job to start after Rails.