### PR TITLE
Improve ec2_swapper role

### DIFF
--- a/ansible/roles/ec2_swapper/defaults/main.yml
+++ b/ansible/roles/ec2_swapper/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 
-ec2_swapper_swap_size: 1G
+# Swap size, expressed as the count of 1M-sized blocks; such that the value for
+# 1 GiB swap is 1024, for 1024 x 1MiB
+ec2_swapper_swap_size: 1024

--- a/ansible/roles/ec2_swapper/tasks/main.yml
+++ b/ansible/roles/ec2_swapper/tasks/main.yml
@@ -3,50 +3,10 @@
 - name: Gather EC2 facts
   action: ec2_facts
 
-- name: Ensure state of instance store mount point
-  file: path=/swap state=directory owner=root group=root mode=0755
+- name: Check whether swap is active
+  shell: "cat /proc/meminfo | awk '/SwapTotal/ {print $2}'"
+  register: swapstatus
+  changed_when: false
 
-- name: Unmount instance store volume that EC2 automatically mounts
-  mount: name=/mnt src=/dev/xvdb fstype=ext3 state=unmounted
-
-- name: Ensure state of filesystem on instance store
-  filesystem: fstype=ext4 dev=/dev/xvdb force=yes
-  when: >-
-    not (ansible_ec2_instance_type | match("^t2") or
-         ansible_ec2_instance_type | match("^m4"))
-
-- name: Make sure that /swap is mounted
-  mount: name=/swap src=/dev/xvdb fstype=ext4 state=mounted
-  when: >-
-    not (ansible_ec2_instance_type | match("^t2") or
-         ansible_ec2_instance_type | match("^m4"))
-
-- name: Check existence of swap file
-  stat: path=/swap/swapfile
-  register: swapfile
-
-- name: Allocate swap file
-  when: not swapfile.stat.exists
-  command: >-
-    fallocate -l {{ ec2_swapper_swap_size }} /swap/swapfile
-
-- name: Format swap file
-  when: not swapfile.stat.exists
-  command: mkswap /swap/swapfile
-
-- name: Ensure swap file permissions
-  file: path=/swap/swapfile owner=root group=root mode=0600
-
-- name: Enable swap
-  when: not swapfile.stat.exists
-  command: swapon /swap/swapfile
-
-- name: Ensure state of swap entry in /etc/fstab
-  mount:
-    name: none
-    src: /swap/swapfile
-    fstype: swap
-    opts: sw
-    passno: 0
-    dump: 0
-    state: present
+- include: needs_swap.yml
+  when: swapstatus.stdout == "0"

--- a/ansible/roles/ec2_swapper/tasks/needs_swap.yml
+++ b/ansible/roles/ec2_swapper/tasks/needs_swap.yml
@@ -1,0 +1,59 @@
+---
+
+## Tasks that are only run when the system does not yet have swap activated.
+#
+
+# EC2 Instance Store volumes are only created and managed for instance types
+# that have Instance Store volumes.  (Which excludes t2 and m4.)
+# Instances that don't have Instance Store volumes will have the /swap
+# directory created on the root volume.
+
+- name: Ensure state of instance store mount point
+  file: path=/swap state=directory owner=root group=root mode=0755
+
+- name: Unmount instance store volume that EC2 automatically mounts
+  mount: name=/mnt state=unmounted src=/dev/xvdb fstype=ext3
+
+- name: Determine whether the instance has an Instance Store volume
+  set_fact:
+    has_instance_store: true
+  when: >-
+    not (ansible_ec2_instance_type | match("^t2") or
+         ansible_ec2_instance_type | match("^m4"))
+
+- name: Ensure state of filesystem on instance store
+  when: has_instance_store is defined
+  filesystem: fstype=ext4 dev=/dev/xvdb force=yes
+
+- name: Make sure that /swap is mounted and in fstab
+  when: has_instance_store is defined
+  mount: name=/swap src=/dev/xvdb fstype=ext4 state=mounted
+
+- name: Check existence of swap file
+  stat: path=/swap/swapfile
+  register: swapfile
+
+- name: Allocate swap file
+  when: not swapfile.stat.exists
+  # See http://www.faqs.org/docs/linux_admin/x1762.html
+  command: >-
+    dd if=/dev/zero of=/swap/swapfile bs=1M count={{ ec2_swapper_swap_size }}
+
+- name: Format swap file
+  command: mkswap /swap/swapfile
+
+- name: Ensure swap file permissions
+  file: path=/swap/swapfile owner=root group=root mode=0600
+
+- name: Enable swap
+  command: swapon /swap/swapfile
+
+- name: Ensure state of swap entry in /etc/fstab
+  mount:
+    name: none
+    src: /swap/swapfile
+    fstype: swap
+    opts: sw
+    passno: 0
+    dump: 0
+    state: present


### PR DESCRIPTION
* Change method of allocating swap file to be less error-prone
* More effectively and safely skip over operations if swap is already active

The specific issue with the old way of allocating swapfile space, with `fallocate`, was that it was producing files with "holes." As mentioned in the comment, you can see http://www.faqs.org/docs/linux_admin/x1762.html for the recommended way with `dd`.

The `main.yml` playbook now skips over a whole range of tasks that are unnecessary if swap is already active on the instance. This should also handle legacy systems pretty well which might have had swap volumes on devices other than `/dev/xvdb`.