### PR TITLE
Remove unwanted template task from marmotta role

### DIFF
--- a/ansible/roles/marmotta/tasks/main.yml
+++ b/ansible/roles/marmotta/tasks/main.yml
@@ -1,14 +1,5 @@
 ---
 
-- name: Ensure sufficient kernel resource limits for the tomcat7 user
-  template:
-    src: etc_security_limits.d_tomcat.conf.j2
-    dest: /etc/security/limits.d/tomcat.conf
-    owner: root
-    group: root
-    mode: 0644
-  notify: restart tomcat
-
 - name: Make sure that old Marmotta APT package list is absent
   file: path=/etc/apt/sources.list.d/marmotta.list state=absent
 


### PR DESCRIPTION
Remove a `template` task that was causing errors due to its file being missing in the `marmotta` role.

Management of a kernel parameters file was moved to the `tomcat_common` role in commit caab9bef6a25 on 2016-09-21.  The `template` task for this file was left in the `marmotta` role although it had been copied to `tomcat_common`.  The template file had been moved and deleted from the `marmotta` role.
