### PR TITLE
Fix mount / unmount in ec2_swapper role

### DIFF
--- a/ansible/roles/ec2_swapper/tasks/needs_swap.yml
+++ b/ansible/roles/ec2_swapper/tasks/needs_swap.yml
@@ -8,11 +8,8 @@
 # Instances that don't have Instance Store volumes will have the /swap
 # directory created on the root volume.
 
-- name: Ensure state of instance store mount point
-  file: path=/swap state=directory owner=root group=root mode=0755
-
 - name: Unmount instance store volume that EC2 automatically mounts
-  mount: name=/mnt state=unmounted src=/dev/xvdb fstype=ext3
+  mount: name=/mnt state=absent src=/dev/xvdb fstype=ext3
 
 - name: Determine whether the instance has an Instance Store volume
   set_fact:
@@ -27,6 +24,7 @@
 
 - name: Make sure that /swap is mounted and in fstab
   when: has_instance_store is defined
+  # "state=mounted" creates mountpoint, if necessary
   mount: name=/swap src=/dev/xvdb fstype=ext4 state=mounted
 
 - name: Check existence of swap file


### PR DESCRIPTION
Fix the usage of the `mount` module in the `ec2_swapper` role so that it removes Ubuntu's `fstab` entry for `/mnt` when it unmounts it.  (The Ansible documentation is actually wrong about the difference between "unmounted" and "absent!")

Also remove the unnecessary `file` task to create the `/swap` directory, because the `mount` module will create it lower down in the file with `state=mounted`.