### PR TITLE
Add new variable for all-in-one hosts

### DIFF
--- a/ansible/group_vars/all.dist
+++ b/ansible/group_vars/all.dist
@@ -79,6 +79,11 @@ thumbp_port: 8007
 nginx_real_ip_from_addrs:
     - 192.168.50.0/24
 
+# Whether each host has all of the services in a local silo, as would be the
+# case in certain QA environments, where the goal is not to simulate the
+# production network environment.
+all_in_one_hosts: no
+
 ##
 # Role-specific vars
 

--- a/ansible/roles/api/templates/database.yml.j2
+++ b/ansible/roles/api/templates/database.yml.j2
@@ -1,7 +1,11 @@
 
 {% if api_alternate_db_host %}
 {%     set db_host = api_alternate_db_host %}
+{% elif all_in_one_hosts | default(false) %}
+{%     set db_host = inventory_hostname %}
 {% else %}
+{# Typical inventories have just one Postgresql host, but it may not be #}
+{# the API host used above. #}
 {%     set db_host = groups['postgresql_dbs'][0] %}
 {% endif %}
 

--- a/ansible/roles/api/templates/dpla.yml.j2
+++ b/ansible/roles/api/templates/dpla.yml.j2
@@ -74,9 +74,15 @@ caching:
 {% if api_dalli_store_cache %}
   store: dalli_store
   memcache_servers:
+
+{% if all_in_one_hosts | default(false) %}
+    - {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}
+{% else %}
 {% for h in groups['memcached'] %}
     - {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}
 {% endfor %}
+{% endif %}
+
 {% else %}
   # file_store directory is tmp/api-cache under the app root
   store: file_store

--- a/ansible/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -26,7 +26,7 @@
 #
 # cluster.name: elasticsearch
 {% if elasticsearch_cluster_name is defined %}
-{% if  elasticsearch_cluster_name_uses_hostname %}
+{% if  all_in_one_hosts | default(false) %}
 cluster.name: {{ elasticsearch_cluster_name }}_{{ inventory_hostname }}
 {% else %}
 cluster.name: {{ elasticsearch_cluster_name }}_{{ level }}
@@ -426,7 +426,11 @@ discovery.zen.ping.multicast.enabled: {{ elasticsearch_discovery_zen_ping_multic
 #
 # discovery.zen.ping.unicast.hosts: ["host1", "host2:port", "host3[portX-portY]"]
 
+{% if all_in_one_hosts | default(false) %}
+discovery.zen.ping.unicast.hosts: ["{{ inventory_hostname }}"]
+{% else %}
 discovery.zen.ping.unicast.hosts: {{ groups['elasticsearch'] | safe }}
+{% endif %}
 
 
 # EC2 discovery allows to use AWS EC2 API in order to perform discovery.

--- a/ansible/roles/frontend/templates/database.yml.j2
+++ b/ansible/roles/frontend/templates/database.yml.j2
@@ -1,7 +1,11 @@
 
 {% if frontend_alternate_db_host %}
 {%     set db_host = frontend_alternate_db_host %}
+{% elif all_in_one_hosts | default(false) %}
+{%     set db_host = inventory_hostname %}
 {% else %}
+{# Typical inventories have just one Postgresql host, but it may not be #}
+{# the frontend host used above. #}
 {%     set db_host = groups['postgresql_dbs'][0] %}
 {% endif %}
 

--- a/ansible/roles/frontend/templates/etc_nginx_sites-available_frontend.j2
+++ b/ansible/roles/frontend/templates/etc_nginx_sites-available_frontend.j2
@@ -9,9 +9,13 @@ server {
 
     server_name {{ frontend_hostname }};
 
+{% if all_in_one_hosts | default(false) %}
+    set_real_ip_from {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }};
+{% else %}
 {% for h in groups['site_proxies'] %}
-    set_real_ip_from {{ hostvars[h][internal_network_interface]['ipv4']['address'] }};
+    set_real_ip_from {{ hostvars[h][internal_network_interface].ipv4.address }};
 {% endfor %}
+{% endif %}
     real_ip_header X-Forwarded-For;
 
     location / {

--- a/ansible/roles/frontend/templates/settings.local.yml.j2
+++ b/ansible/roles/frontend/templates/settings.local.yml.j2
@@ -38,9 +38,13 @@ session:
   # Settings for memcache sessions
   dalli_store:
     memcache_server:
+{% if all_in_one_hosts | default(false) %}
+      - {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}
+{% else %}
 {% for h in groups['memcached'] %}
       - {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}
 {% endfor %}
+{% endif %}
 
 widgets:
   twitter_username: {{ twitter_username }}

--- a/ansible/roles/ingestion_app/templates/database.yml.j2
+++ b/ansible/roles/ingestion_app/templates/database.yml.j2
@@ -1,7 +1,11 @@
 
 {% if ingestion_app_alternate_db_host %}
 {%     set db_host = ingestion_app_alternate_db_host %}
+{% elif all_in_one_hosts | default(false) %}
+{%     set db_host = inventory_hostname %}
 {% else %}
+{# Typical inventories have just one Postgresql host, but it may not be #}
+{# the ingestion app host used above. #}
 {%     set db_host = groups['postgresql_dbs'][0] %}
 {% endif %}
 

--- a/ansible/roles/loadbalancer/templates/haproxy.cfg.j2
+++ b/ansible/roles/loadbalancer/templates/haproxy.cfg.j2
@@ -70,13 +70,11 @@ frontend elasticsearch-in
     default_backend elasticsearch
 
 backend elasticsearch
-{% if ingestion2 is not defined %}
-    server dbnode1 192.168.50.4:9200 maxconn 500
-    server dbnode2 192.168.50.4:9200 maxconn 500
-{% else %}
-    server dev1 192.168.50.7:9200 maxconn 500
-{% endif %}
+{% for h in groups.elasticsearch %}
+    server {{ h }} {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}:9200 maxconn 500
+{% endfor %}
 
+# ... end Elasticsearch
 {% endif %}
 
 
@@ -94,7 +92,12 @@ frontend api-http-in
 	default_backend api-http
 
 backend api-http
-	{% set apihost = groups['api'][0] %}
+{% if all_in_one_hosts | default(false) %}
+{%    set apihost = inventory_hostname %}
+{% else %}
+{%    set apihost = groups.api.0 %}
+{% endif %}
 	server {{ apihost }} {{ hostvars[apihost][internal_network_interface]['ipv4']['address']}}:{{ api_app_port }}
 
+# ... end API
 {% endif %}

--- a/ansible/roles/postgresql/templates/pg_hba.conf.j2
+++ b/ansible/roles/postgresql/templates/pg_hba.conf.j2
@@ -74,41 +74,54 @@
 
 # hostvars[h][internal_network_interface]['ipv4']['address']
 
-{% for host in groups['frontend'] %}
+{% if all_in_one_hosts | default(false) %}
+
+host all all {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}/32 md5
+
+{% else %}
+
+{% if groups.frontend is defined %}
+{% for host in groups.frontend %}
 host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
-{% for host in groups['api'] %}
+{% endif %}
+
+{% for host in groups.api %}
 host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 
 {# The `cms` group needs access because of the pss app #}
-{% if groups['cms'] is defined %}
-{% for host in groups['cms'] %}
+{% if groups.cms is defined %}
+{% for host in groups.cms %}
 host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 {% endif %}
 
-{# The following hosts are for the new Ingestion 2 system. #}
+{# The following hosts are for the Ingestion 2 system. #}
 {# TODO:  Remove the `if' statements when we do away with the legacy #}
 {#        ingestion system. #}
 
-{% if groups['ingestion_app'] is defined %}
-{% for host in groups['ingestion_app'] %}
+{% if groups.ingestion_app is defined %}
+{% for host in groups.ingestion_app %}
 host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 {% endif %}
 
-{% if groups['worker'] is defined %}
-{% for host in groups['worker'] %}
+{% if groups.worker is defined %}
+{% for host in groups.worker %}
 host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 {% endif %}
 
-{% if groups['marmotta'] is defined %}
+{% if groups.marmotta is defined %}
 {% for host in groups['marmotta'] %}
 host all all {{ hostvars[host][internal_network_interface].ipv4.address }}/32 md5
 {% endfor %}
 {% endif %}
+
+{# End "if all_in_one_hosts" #}
+{% endif %}
+
 
 # Deny access to postgresql user from other hosts
 host    all             postgres       0.0.0.0/0               reject

--- a/ansible/roles/pss/templates/database.yml.j2
+++ b/ansible/roles/pss/templates/database.yml.j2
@@ -1,6 +1,10 @@
 {% if pss_alternate_db_host %}
 {%     set db_host = pss_alternate_db_host %}
+{% elif all_in_one_hosts | default(false) %}
+{%     set db_host = inventory_hostname %}
 {% else %}
+{# Typical inventories have just one Postgresql host, but it may not be #}
+{# the PSS application host used above. #}
 {%     set db_host = groups['postgresql_dbs'][0] %}
 {% endif %}
 

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -182,9 +182,13 @@ upstream dpla_portal {
 {% if groups.thumbp is defined %}
 # Thumbnail proxy servers
 upstream dpla_thumbp {
+{% if all_in_one_hosts | default(false) %}
+    server {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}:{{ thumbp_port }} fail_timeout=120s; # {{ inventory_hostname }}
+{% else %}
 {% for h in groups.thumbp %}
     server {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}:{{ thumbp_port }} fail_timeout=120s; # {{ h }}
 {% endfor %}
+{% endif %}
 }
 {% endif %}
 


### PR DESCRIPTION
Add a new variable, `all_in_one_hosts`, which governs whether each host in the inventory is self-contained, with no dependencies on other servers. This defaults to False, so no changes should be necessary for typical developer usage. This is for particular DPLA-specific use cases, like QA, and is not relevant to either production or development VM environments.

Also normalize some of the dict variable dereferencing syntax throughout various files, for a cleaner look, and for consistency. For example, change `groups['cms']` to `groups.cms`.