### PR TITLE
Fix BigCouch cluster assignment, all-in-one hosts

### DIFF
--- a/ansible/roles/dbnode/tasks/main.yml
+++ b/ansible/roles/dbnode/tasks/main.yml
@@ -80,8 +80,8 @@
   uri: >-
       url="http://{{ inventory_hostname }}:5986/nodes/{{ dbnode_id_name }}@{{ item }}"
       method=PUT body="{}" status_code="201,409"
-  with_items: groups['dbnodes']
-  when: dbnode_inventory_hosts_are_nodes
+  with_items: groups.dbnodes
+  when: not all_in_one_hosts
   tags:
     - database
 
@@ -92,7 +92,7 @@
   uri: >-
       url="http://{{ inventory_hostname }}:5986/nodes/{{ dbnode_id_name }}@{{ inventory_hostname }}"
       method=PUT body="{}" status_code="201,409"
-  when: not dbnode_inventory_hosts_are_nodes
+  when: all_in_one_hosts
   tags:
     - database
 


### PR DESCRIPTION
Fix the command to assign hosts to a BigCouch cluster so that only the local host is assigned when `all_in_one_hosts` is True.

This was left out of 918cd2e