### PR TITLE
Fix deployment gem issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,22 +194,19 @@ network.  For example:
 $ ssh me@webapp1
 ```
 
-### Suggested development workflow
+## Development
 
-Here's an example with the API app.  The process would be similiar for the frontend
-app.
+### Application build directories
 
-1. Configure ansible/roles/vars/development.yml with `api_use_local_source: true`
-   and have a `webapp.vm.synced_folder` entry in your `Vagrantfile` for your
-   local working copy of the project.
-2. Make your changes to the local working copy.
-3. In a shell (assuming you're in the directory with `ansible.cfg`):
-```
-$ ansible-playbook -u <your username> -i development \
-  playbooks/deploy_api_development.yml
-```
+There are a number of `clean_*` variables for redeploying various
+applications.  If you are deploying earlier versions of the applications and
+you run into errors when they are being checked out into their build
+directories, you may need to set the appropriate variable with the
+`ansible-playbook` command, such as `-e 'clean_api=true'`. This can also be
+useful when a switch between branches would result in a merge conflict with a
+file that has been added or removed in one version or the other.
 
-Repeat 2 and 3.
+### Using local sources on your system, not from a repository
 
 Please note that, if you're using `*_use_local_source: true` for any
 application, you'll be responsible for managing the state of your configuration

--- a/ansible/roles/api/files/build_api.sh
+++ b/ansible/roles/api/files/build_api.sh
@@ -14,7 +14,6 @@ rbenv shell $USE_VERSION >> $LOGFILE 2>&1
 
 echo "installing bundle ..." >> $LOGFILE
 
-rm -f Gemfile.lock
 bundle install >> $LOGFILE 2>&1 || exit 1
 rbenv rehash
 

--- a/ansible/roles/api/tasks/deploy.yml
+++ b/ansible/roles/api/tasks/deploy.yml
@@ -1,7 +1,18 @@
 ---
 
 # Clear these out prior to copying and symlinking below
-- file: path=/home/dpla/api state=absent
+
+- name: Clear /home/dpla/api symlink
+  file: path=/home/dpla/api state=absent
+
+- name: Make sure that API build directories are clear
+  when: clean_api | default(false)
+  file:
+    path: "/home/dpla/{{ item }}"
+    state: absent
+  with_items:
+    - api-git
+    - api-local
 
 - name: Check out api (platform) app from its repository (git)
   git: >-

--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -35,6 +35,12 @@ echo "using rbenv version $USE_VERSION" >> $LOGFILE
 
 echo "installing bundle ..." >> $LOGFILE
 
+# We're using Gemfile.lock in other DPLA Rails applications for its intended
+# purpose, but the `portal' application is an exception due to its inclusion of
+# the dpla_frontend_assets gem. We remove Gemfile.lock and pin gems with
+# explicit selectors in Gemfile. Removing Gemfile.lock allows gems to upgrade as
+# specified. It's too complicated to manage the dpla_frontend_assets gem as an
+# optional inclusion when there is a Gemfile.lock file.
 rm -f Gemfile.lock
 bundle install --without test >> $LOGFILE 2>&1
 if [ $? -ne 0 ]; then

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -1,7 +1,17 @@
 ---
 
-# Clear this out prior to copying and symlinking below
-- file: path=/home/dpla/frontend state=absent
+- name: Clear /home/dpla/frontend symlink
+  # It will be recreated below
+  file: path=/home/dpla/frontend state=absent
+
+- name: Make sure that frontend build directories are clear
+  when: clean_frontend | default(false)
+  file:
+    path: "/home/dpla/{{ item }}"
+    state: absent
+  with_items:
+    - frontend-git
+    - frontend-local
 
 - name: Check out frontend app from its repository
   git: >-

--- a/ansible/roles/pss/files/build_pss.sh
+++ b/ansible/roles/pss/files/build_pss.sh
@@ -23,7 +23,6 @@ rbenv shell $USE_VERSION
 echo "using version ${USE_VERSION} ..." >> $LOGFILE
 echo "installing bundle ..." >> $LOGFILE
 
-rm -f Gemfile.lock
 bundle install >> $LOGFILE 2>&1
 if [ $? -ne 0 ]; then
     exit 1

--- a/ansible/roles/pss/tasks/deploy.yml
+++ b/ansible/roles/pss/tasks/deploy.yml
@@ -1,7 +1,17 @@
 ---
 
-# Clear this out prior to copying and symlinking below
-- file: path=/home/dpla/pss state=absent
+- name: Clear /home/dpla/pss symlink
+  # It will be recreated below.
+  file: path=/home/dpla/pss state=absent
+
+- name: Make sure that PSS build directories are clear
+  when: clean_pss | default(false)
+  file:
+    path: "/home/dpla/{{ item }}"
+    state: absent
+  with_items:
+    - pss-git
+    - pss-local
 
 - name: Check out primary-source-sets app from its repository
   git: >-


### PR DESCRIPTION
* Fix various deployments to honor our new strategy of using `Gemfile.lock` as it was intended.
* Provide `clean_*` variables for more roles, to allow build directories to be cleared.
* Update `README.md` with advice on using the `clean_*` variables. Also remove some  information that is misleading because it is incomplete. It should be covered elsewhere.

The changes here are to fix problems with Ruby gems being upgraded out from under us and breaking deployments. To keep ourselves from having to diligently pin random gems in our Gemfiles, we have decided to use Gemfile.lock files for their intended purpose. We must therefore stop removing Gemfile.lock before we do a `bundle install`.

The heidrun and frontend applications are exceptions. (Heidrun is deployed in the ingestion_app role.)  These applications have complicating factors that prevent us from using a Gemfile.lock at the moment.  Frontend has some optionally-included assets in a private repository and ingestion_app, and heidrun's development configuration requires a little more thought related to local versus repository deployments before committing anything.

This changeset assumes that you will deploy current versions of the platform, frontend, and primary-source-sets applications, which have Gemfile.lock files! If you want to deploy an old version, use the relevant clean_ variable on the commandline with ansible-playbook, such as `-e 'clean_api=true'`.
