### PR TITLE
Fix more all_in_one_hosts issues

### DIFF
--- a/ansible/roles/common/templates/hosts.j2
+++ b/ansible/roles/common/templates/hosts.j2
@@ -7,12 +7,16 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 
+{% if all_in_one_hosts | default(false) %}
+{{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}  {{ h | replace('_', '-')}}
+{% else %}
 {% for h in groups[all_group_name] %}
 {# Hostnames should not have underscores, but dynamic inventories (particularly,
    EC2) can have names with underscores. They have to be converted to use
    hyphens. #}
 {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}	{{ h | replace('_', '-')}}
 {% endfor %}
+{% endif %}
 
 {% if level is defined and level == 'development' %}
 {% if ingestion2 is defined %}

--- a/ansible/roles/common_sitenode/templates/etc_nginx_conf.d_trustedproxyips.j2
+++ b/ansible/roles/common_sitenode/templates/etc_nginx_conf.d_trustedproxyips.j2
@@ -5,6 +5,10 @@
 
 # identify and use ip address from trusted proxy connections
 real_ip_header X-Forwarded-For;
+{% if all_in_one_hosts | default(false) %}
+set_real_ip_from {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}
+{% else %}
 {% for h in groups['site_proxies'] %}
 set_real_ip_from {{ hostvars[h][internal_network_interface]['ipv4']['address'] }};
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
Fix more issues with configuration files when all_in_one_hosts is true. The `/etc/hosts` file and the NGiNX trusted proxy IPs file should just use the single inventory host instead of iterating through an inventory group.
