### PR TITLE
Fix /etc/hosts variable for current inventory hostname

### DIFF
--- a/ansible/roles/common/templates/hosts.j2
+++ b/ansible/roles/common/templates/hosts.j2
@@ -8,7 +8,7 @@ ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 
 {% if all_in_one_hosts | default(false) %}
-{{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}  {{ h | replace('_', '-')}}
+{{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}  {{ inventory_hostname | replace('_', '-')}}
 {% else %}
 {% for h in groups[all_group_name] %}
 {# Hostnames should not have underscores, but dynamic inventories (particularly,


### PR DESCRIPTION
The bad variable name `h` was causing a playbook error.