### PR TITLE
Fix and improve the ability to operate all-in-one servers

### DIFF
--- a/ansible/group_vars/all.dist
+++ b/ansible/group_vars/all.dist
@@ -65,7 +65,7 @@ marmotta_domain: ldp.local.dp.la
 default_http_scheme: http
 # api_port is the port the *loadbalancer* answers on for API requests
 api_port: 8080
-# api_app_port is the port the *backend app server* runs on
+# *_app_port is the port the *backend app server* runs on
 api_app_port: 8003
 exhibitions_app_port: 8000
 wordpress_app_port: 8001
@@ -73,8 +73,12 @@ frontend_app_port: 8002
 ingestion_app_port: 8004
 # port 8005 is used by Tomcat
 pss_app_port: 8006
-siteproxy_port: 80
+# thumbp_port is not exposed to the outside world. It's just internal, though
+# it's not named thumbp_app_port.
 thumbp_port: 8007
+# siteproxy_port is what the site proxy listens on; but it could additionally
+# sit behind another loadbalancer
+siteproxy_port: 80
 
 nginx_real_ip_from_addrs:
     - 192.168.50.0/24

--- a/ansible/roles/loadbalancer/templates/haproxy.cfg.j2
+++ b/ansible/roles/loadbalancer/templates/haproxy.cfg.j2
@@ -47,17 +47,21 @@ frontend web-http-in
 	bind *:80
 	default_backend web-http
 
+{% if default_http_scheme == 'https' %}
 frontend web-https-in
 	bind *:443 ssl crt /etc/ssl/certs/local.dp.la.pem
 	mode http
 	reqadd X-Forwarded-Proto:\ https
 	default_backend web-http
+{% endif %}
 
 backend web-http
-{% if ingestion2 is not defined %}
-	server webapp1 192.168.50.6:{{ siteproxy_port }} maxconn 500
+{% if all_in_one_hosts | default(false) %}
+	server {{ inventory_hostname }} {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}:{{ siteproxy_port }} maxconn 500
 {% else %}
-	server dev1 192.168.50.7:{{ siteproxy_port }} maxconn 500
+{% for h in groups.site_proxies %}
+	server {{ h }} {{ hostvars[h][internal_network_interface].ipv4.address }}:{{ siteproxy_port }} maxconn 500
+{% endfor %}
 {% endif %}
 
 # ... end Web

--- a/ansible/roles/site_proxy/defaults/main.yml
+++ b/ansible/roles/site_proxy/defaults/main.yml
@@ -50,3 +50,7 @@ siteproxy_nginx_cache_inactive_time: 1d
 siteproxy_self_ssl: false
 
 siteproxy_redirect_home_path: /info
+
+# Whether to disallow robots, when they would normally be allowed; for example,
+# when level == production
+siteproxy_disallow_robots: false

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -146,36 +146,52 @@ limit_req_log_level {{ siteproxy_nginx_limit_req_log_level }};
 {% if groups.wordpress is defined %}
 # Wordpress servers
 upstream dpla_wp {
+{% if all_in_one_hosts %}
+    server {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}:{{ wordpress_app_port }} fail_timeout=120s;  # {{ inventory_hostname }}
+{% else %}
 {% for h in groups.wordpress %}
     server {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}:{{ wordpress_app_port }} fail_timeout=120s;  # {{ h }}
 {% endfor %}
+{% endif %}
 }
 {% endif %}
 
 {% if groups.exhibitions is defined %}
 # Exhibitions servers
 upstream dpla_omeka {
+{% if all_in_one_hosts %}
+    server {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}:{{ exhibitions_app_port }} fail_timeout=120s;  # {{ inventory_hostname }}
+{% else %}
 {% for h in groups.exhibitions %}
     server {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}:{{ exhibitions_app_port }} fail_timeout=120s;  # {{ h }}
 {% endfor %}
+{% endif %}
 }
 {% endif %}
 
 {% if groups.pss is defined %}
 # Primary Source Sets servers
 upstream dpla_pss {
+{% if all_in_one_hosts %}
+    server {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}:{{ pss_app_port }} fail_timeout=120s;  # {{ inventory_hostname }}
+{% else %}
 {% for h in groups.pss %}
     server {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}:{{ pss_app_port }} fail_timeout=120s;  # {{ h }}
 {% endfor %}
+{% endif %}
 }
 {% endif %}
 
 {% if groups.frontend is defined %}
 # Frontend (portal) servers
 upstream dpla_portal {
+{% if all_in_one_hosts %}
+    server {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}:{{ frontend_app_port }} fail_timeout=120s;  # {{ inventory_hostname }}
+{% else %}
 {% for h in groups.frontend %}
     server {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}:{{ frontend_app_port }} fail_timeout=120s;  # {{ h }}
 {% endfor %}
+{% endif %}
 }
 {% endif %}
 

--- a/ansible/roles/site_proxy/templates/robots.txt.j2
+++ b/ansible/roles/site_proxy/templates/robots.txt.j2
@@ -1,6 +1,6 @@
 User-agent: *
 
-{% if level == 'production' %}
+{% if level == 'production' and not siteproxy_disallow_robots %}
 
 Disallow: /search
 Disallow: /timeline


### PR DESCRIPTION
* Add comments to clarify the assignment of port numbers
* Fix `haproxy` configuration: remove hardcoded `server` parameters and write the frontend SSL configuration only when it's appropriate to do so.
* Optionally disallow spidering even in production
* Make all NGiNX `upstream` directives consistent in the `site_proxy` role.

Addresses https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-566