### PR TITLE
Add assertion of libssl-dev package, for frontend

### DIFF
--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -12,6 +12,7 @@
     - libreadline6
     - libreadline6-dev
     - g++
+    - libssl-dev
   when: not skip_configuration | default(false)
   tags:
     - packages


### PR DESCRIPTION
This package is required for `rbenv` to compile Ruby with SSL support, which is necessary when running `bundle install`. There seems to have been a recent change (within the last week) in an Ubuntu package's dependencies that has stopped `libssl-dev` from being installed without our explicitly requesting it.