### PR TITLE
Upgrade Ubuntu to 14.04 LTS

### DIFF
--- a/README-ingestion2.md
+++ b/README-ingestion2.md
@@ -15,12 +15,11 @@ See the upgrade notes in [README.md](README.md).
 
 ## Steps
 
-* Copy `Vagrantfile.ingestion2` to `Vagrantfile`
+* Copy `Vagrantfile.ingestion2` to `Vagrantfile`.  (Not `Vagrantfile.dist`)
 
-* Make sure that Vagrant has downloaded the base server images that we'll need
+* Make sure that Vagrant has downloaded the base server image that we'll need
   for our VMs:
 ```
-$ vagrant box add hashicorp/precise64
 $ vagrant box add ubuntu/trusty64
 ```
 * Add the following entries to your /etc/hosts file or the equivalent for your

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ machine with at least 8 GB of memory.
 
 Please install the following tools as documented on their websites:
 
-* [VirtualBox](https://www.virtualbox.org/) (Version 4.3)
-* [Vagrant](http://www.vagrantup.com/) (Version 1.6)
+* [VirtualBox](https://www.virtualbox.org/) (Version 5)
+* [Vagrant](http://www.vagrantup.com/) (Version 1.8)
 * [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest/) (`vagrant plugin install vagrant-vbguest`)
-* [Ansible](http://www.ansible.com/) (Version 1.9) [installation instructions](http://docs.ansible.com/intro_installation.html)
+* [Ansible](http://www.ansible.com/) (Version 1.9) (Version 2.x will definitely not work) [installation instructions](http://docs.ansible.com/intro_installation.html)
 * Additional dependencies described in the `pip` requirements file (see below)
 
 ### Steps
@@ -65,11 +65,11 @@ If you want to work with our new Ingestion2 system, please see
       override the `*_use_local_source` variables in some of the roles'
       `defaults` directories, as well as the variables related to the source
       directories.
-* Copy `Vagrantfile.dist` to `Vagrantfile`.
+* Copy `Vagrantfile.dist` to `Vagrantfile`. If you want to perform development work on any of the DPLA applications that will be installed, see the comments in `Vagrantfile` about mounting their working copy directories for "local" deployments.
 * Make sure that Vagrant has downloaded the base server image that we'll need
   for our VMs:
 ```
-$ vagrant box add hashicorp/precise64
+$ vagrant box add ubuntu/trusty64
 ```
 * Add the following entries to your /etc/hosts file or the equivalent for your
   operating system:

--- a/Vagrantfile.dist
+++ b/Vagrantfile.dist
@@ -23,16 +23,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # know about all the generated ones.
     config.ssh.insert_key = false
 
-    # All boxes are hashicorp/precise64, which is Ubuntu 12.04 LTS
+    # All boxes are ubuntu/trusty64, which is Ubuntu 14.04 LTS
 
     # BigCouch and ElasticSearch servers.
     # Necessary in all cases.
     dbnodes.keys.each do |hostname|
 	    config.vm.define hostname do |dbnode|
-	        dbnode.vm.box = "hashicorp/precise64"
+	        dbnode.vm.box = "ubuntu/trusty64"
 	        dbnode.vm.network :private_network, ip: dbnodes[hostname]
 	        dbnode.vm.provider "virtualbox" do |vb|
-	            vb.memory = 1024
+	            vb.memory = 819
 	        end
 	    end
     end
@@ -40,10 +40,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Loadbalancer for development.
     # Necessary in all cases.
     config.vm.define :loadbal do |loadbal|
-        loadbal.vm.box = "hashicorp/precise64"
+        loadbal.vm.box = "ubuntu/trusty64"
         loadbal.vm.network :private_network, ip: "192.168.50.2"
         loadbal.vm.provider "virtualbox" do |vb|
-            vb.memory = 256
+            vb.memory = 307
         end
     end
 
@@ -52,10 +52,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # which playbook you run.)
     # Necessary in all cases.
     config.vm.define :webapp1 do |webapp|
-        webapp.vm.box = "hashicorp/precise64"
+        webapp.vm.box = "ubuntu/trusty64"
         webapp.vm.network :private_network, ip: "192.168.50.6"
         webapp.vm.provider "virtualbox" do |vb|
-            vb.memory = 768
+            vb.memory = 1228
         end
         #
         # *** EDIT THESE FOR LOCAL DEVELOPMENT ***

--- a/Vagrantfile.ingestion2
+++ b/Vagrantfile.ingestion2
@@ -18,7 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Frontend, web, ElasticSearch
   config.vm.define :dev1 do |dev1|
-    dev1.vm.box = 'hashicorp/precise64'  # Ubuntu 12.04 LTS
+    dev1.vm.box = 'ubuntu/trusty64'  # Ubuntu 14.04 LTS
     dev1.vm.network :private_network, ip: '192.168.50.7'
     dev1.vm.provider :virtualbox do |vb|
       vb.memory = 2048  # 2 GiB

--- a/ansible/roles/api/defaults/main.yml
+++ b/ansible/roles/api/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-api_unicorn_worker_processes: 2
+api_unicorn_worker_processes: 1
 api_use_local_source: false
 api_branch_or_tag: master
 api_rails_env: development

--- a/ansible/roles/common/files/etc_default_sysstat
+++ b/ansible/roles/common/files/etc_default_sysstat
@@ -7,12 +7,3 @@
 # are "true" and "false". Please do not put other values, they
 # will be overwritten by debconf!
 ENABLED="true"
-
-# Additional options passed to sa1 by /etc/init.d/sysstat
-# and /etc/cron.d/sysstat
-# By default contains the `-S DISK' option responsible for
-# generating disk statisitcs.
-SA1_OPTIONS="-S DISK"
-
-# Additional options passed to sa2 by /etc/cron.daily/sysstat.
-SA2_OPTIONS=""

--- a/ansible/roles/common/files/ssh_config
+++ b/ansible/roles/common/files/ssh_config
@@ -47,6 +47,7 @@ Host *
 #   PermitLocalCommand no
 #   VisualHostKey no
 #   ProxyCommand ssh -q -W %h:%p gateway.example.com
+#   RekeyLimit 1G 1h
     SendEnv LANG LC_*
     HashKnownHosts yes
     GSSAPIAuthentication yes

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -136,11 +136,13 @@
   tags:
     - authorized_keys
     - users
+    - ssh
 
 - name: Update SSH client configuration
   copy: src=ssh_config dest=/etc/ssh/ssh_config owner=root group=root mode=0644
   tags:
     - packages
+    - ssh
 
 - name: Update systemwide SSH known hosts
   copy: >

--- a/ansible/roles/common/templates/munin-node.conf.j2
+++ b/ansible/roles/common/templates/munin-node.conf.j2
@@ -12,10 +12,18 @@ setsid 1
 user root
 group root
 
-# Regexps for files to ignore
+# This is the timeout for the whole transaction.
+# Units are in sec. Default is 15 min
+#
+# global_timeout 900
 
-ignore_file ~$
-#ignore_file [#~]$  # FIX doesn't work. '#' starts a comment
+# This is the timeout for each plugin.
+# Units are in sec. Default is 1 min
+#
+timeout 60
+
+# Regexps for files to ignore
+ignore_file [\#~]$
 ignore_file DEADJOE$
 ignore_file \.bak$
 ignore_file %$
@@ -60,6 +68,3 @@ host {{ hostvars[inventory_hostname][internal_network_interface]['ipv4']['addres
 
 # And which port
 port 4949
-
-# timeout:  default is 20? http://munin-monitoring.org/wiki/munin-node.conf
-timeout 60

--- a/ansible/roles/common_php/files/etc_logrotate.d_php5-fpm
+++ b/ansible/roles/common_php/files/etc_logrotate.d_php5-fpm
@@ -8,6 +8,6 @@
     notifempty
     create 0600 root root
     postrotate
-        service php5-fpm reload > /dev/null
+        /usr/lib/php5/php5-fpm-reopenlogs
     endscript
 }

--- a/ansible/roles/dbnode/files/build_libicu48.sh
+++ b/ansible/roles/dbnode/files/build_libicu48.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+set -u
+
+exit_w_error() {
+    echo >&2 $1
+    echo $1 >> $log
+    exit 1
+}
+
+cd /var/tmp
+rm -rf icu
+tar zxf icu4c-4_8_1_1-src.tgz || exit_w_error "Can not extract tar file"
+cd icu/source
+./runConfigureICU Linux || exit_w_error "Can not configure libicu48"
+make 2>&1 > /var/tmp/make.out || exit_w_error "Can not make libicu48"
+make install 2>&1 > /var/tmp/install.log || \
+    exit_w_error "Can not install libicu48"
+
+cd /var/tmp
+equivs-build libicu48 || exit_w_error "Can not build libicu48 package equiv"
+dpkg -i libicu48_4.8-1_all.deb || \
+    exit_w_error "Can not install dummy libicu48 package"
+
+exit 0

--- a/ansible/roles/dbnode/files/libicu48
+++ b/ansible/roles/dbnode/files/libicu48
@@ -1,0 +1,6 @@
+Section: misc
+Priority: optional
+Standards-Version: 3.9.2
+Package: libicu48
+Version: 4.8-1
+Description: Dummy libicu48 package

--- a/ansible/roles/dbnode/tasks/main.yml
+++ b/ansible/roles/dbnode/tasks/main.yml
@@ -6,8 +6,14 @@
     - packages
     - database
 
-- name: Ensure that runit is installed
-  apt: name=runit state=present
+- name: Ensure that prerequisite packages are installed
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - runit
+    - g++
+    - equivs
   tags:
     - packages
     - database
@@ -22,6 +28,18 @@
 - name: Figure out if the BigCouch package has to be downloaded
   stat: path=/var/tmp/bigcouch_0.4.2-1_amd64.deb
   register: bigcouch_deb
+  tags:
+    - packages
+    - database
+
+- name: Figure out if libicu48 is installed
+  command: dpkg-query -s libicu48
+  ignore_errors: yes
+  register: dpkgquery
+
+- name: Figure out if the libicu source has to be downloaded
+  stat: path=/var/tmp/icu4c-4_8_1_1-src.tgz
+  register: libicu_source
   tags:
     - packages
     - database
@@ -46,8 +64,32 @@
     - packages
     - database
 
+- name: "Download libicu source, if necessary"
+  get_url: >-
+    url="http://download.icu-project.org/files/icu4c/4.8.1.1/icu4c-4_8_1_1-src.tgz"
+    dest="/var/tmp/icu4c-4_8_1_1-src.tgz"
+  when: (not libicu_source.stat.exists) and (dpkgquery.rc != 0)
+  tags:
+    - packages
+    - database
+
 - name: Ensure installation of Spidermonkey javascript engine
   apt: deb=/var/tmp/libmozjs185-cloudant_1.8.5-cloudant1_amd64.deb
+  tags:
+    - packages
+    - database
+
+- name: Copy apt package equivs config file into place
+  copy:
+    src: libicu48
+    dest: /var/tmp/libicu48
+  tags:
+    - packages
+    - database
+
+- name: Compile and install libicu48
+  script: ../files/build_libicu48.sh
+  when: dpkgquery.rc != 0
   tags:
     - packages
     - database
@@ -64,6 +106,14 @@
     - restart bigcouch
   tags:
    - database
+
+- name: Make sure that bigcouch can find libicu48
+  lineinfile:
+    dest: /etc/service/bigcouch/run
+    regexp: LD_LIBRARY_PATH
+    line: export LD_LIBRARY_PATH=/usr/local/lib
+    insertbefore: '^exec chpst'
+    state: present
 
 - name: Update bigcouch VM args file
   template: src=vm.args.erb.j2 dest=/opt/bigcouch/etc/vm.args

--- a/ansible/roles/frontend/defaults/main.yml
+++ b/ansible/roles/frontend/defaults/main.yml
@@ -2,7 +2,7 @@
 
 frontend_rails_env: development
 frontend_rbenv_version: 1.9.3-p547
-frontend_unicorn_worker_processes: 2
+frontend_unicorn_worker_processes: 1
 frontend_use_local_source: false
 frontend_branch_or_tag: master
 frontend_s3_bucket: changeme

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -2,8 +2,8 @@
 
 postgresql_user: {name: "dpla", password: "changeme"}
 # These memory-related values are tuned to the size of the development VM.
-pg_max_connections: 50
-pg_shared_buffers: 24MB
+pg_max_connections: 10
+pg_shared_buffers: 16MB
 pg_effective_cache_size: 128MB
 pg_work_mem: 1MB
 pg_maintenance_work_mem: 16MB

--- a/ansible/roles/pss/defaults/main.yml
+++ b/ansible/roles/pss/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-pss_unicorn_worker_processes: 2
+pss_unicorn_worker_processes: 1
 pss_use_local_source: false
 pss_branch_or_tag: master
 pss_rails_env: development

--- a/ansible/roles/pss/tasks/main.yml
+++ b/ansible/roles/pss/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Ensure existence of necessary packages
+- name: Ensure existence of necessary PSS packages
   apt: >-
     pkg="{{ item }}" state=present
   with_items:
@@ -12,6 +12,7 @@
     - libreadline6
     - libreadline6-dev
     - libfontconfig1-dev
+    - libssl-dev
   when: not skip_configuration
   tags:
     - packages

--- a/ansible/roles/site_proxy/defaults/main.yml
+++ b/ansible/roles/site_proxy/defaults/main.yml
@@ -39,9 +39,9 @@ siteproxy_nginx_limit_conn_log_level: notice
 siteproxy_nginx_limit_req_log_level: notice
 
 # Maximum disk space used by the NGINX cache. Our default is 6 Gb.
-siteproxy_nginx_cache_max_size: 5120m
+siteproxy_nginx_cache_max_size: 1024m
 # Size of shared memory zone that is used for NGINX cache
-siteproxy_nginx_cache_shmem_size: 360m
+siteproxy_nginx_cache_shmem_size: 100m
 # How long an item can remain in the cache without being accessed, independently
 # of how long its expiration time is, or the value of the proxy_cache_valid
 # directive:


### PR DESCRIPTION
Update README files with updated installation instructions.

Update Vagrantfiles with new vagrant box names, and more memory allocation for the 'loadbal' VM.

Update 'common' role with changes to configuration files that coordinate with new package versions.

Update 'dbnode' role to work around broken dependency in 'bigcouch' package that was intended for Ubuntu 12.04.

Update 'pss' role to install libssl-dev dependency that is required by rbenv's build of Ruby 2.1. There must have been a depcndency cascade in Ubuntu 12.04 that caused it to be installed previously, whereas it was missing under 14.04.

It seems like there is more memory being allocated on these VMs with Ubuntu 14.04, which can lead to out-of-memory situations; so reduce memory usage by the following means:
* Lower the default PostgreSQL max_connections and shared_buffers
* Lower the default NGINX cache maximum size and shared memory size
* Lower the default number of Unicorn workers across various roles

Also allocate more memory to webapp1 to get around out-of-memory problems with the frontend build.