### PR TITLE
Improve "clean" deployments, various apps

### DIFF
--- a/ansible/roles/api/tasks/deploy.yml
+++ b/ansible/roles/api/tasks/deploy.yml
@@ -54,6 +54,14 @@
       src=unicorn.rb.j2 dest=/home/api/api/config/unicorn.rb
       owner=api group=api mode=0644
 
+# To use "Clean rbenv", define the variable `clean_rbenv', which is not defined
+# anywhere by default.
+- name: Clean rbenv
+  file:
+    path: /home/api/.rbenv
+    state: absent
+  when: clean_rbenv | default(false)
+
 - name: Make sure rbenv and bundler are current
   script: >
       ../../../files/install_ruby_tools.sh {{ api_rbenv_version }}

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -61,6 +61,14 @@
     line="gem 'dpla_frontend_assets', git: 'git@github.com:dpla/frontend-assets.git'"
   when: frontend_include_branding
 
+# To use "Clean rbenv", define the variable `clean_rbenv', which is not defined
+# anywhere by default.
+- name: Clean rbenv
+  file:
+    path: /home/frontend/.rbenv
+    state: absent
+  when: clean_rbenv | default(false)
+
 - name: Make sure rbenv and bundler are current
   script: >
       ../../../files/install_ruby_tools.sh {{ frontend_rbenv_version }}

--- a/ansible/roles/pss/tasks/deploy.yml
+++ b/ansible/roles/pss/tasks/deploy.yml
@@ -66,6 +66,14 @@
     line="gem 'dpla_frontend_assets', git: 'git@github.com:dpla/frontend-assets.git'"
   when: pss_include_branding
 
+# To use "Clean rbenv", define the variable `clean_rbenv', which is not defined
+# anywhere by default.
+- name: Clean rbenv
+  file:
+    path: /home/pss/.rbenv
+    state: absent
+  when: clean_rbenv | default(false)
+
 - name: Make sure that rbenv and bundler are current
   script: >-
       ../../../files/install_ruby_tools.sh {{ pss_rbenv_version }}

--- a/ansible/roles/thumbp/tasks/main.yml
+++ b/ansible/roles/thumbp/tasks/main.yml
@@ -14,7 +14,7 @@
     - users
 
 - name: Ensure state of log directory
-  file: path=/var/log/thumbp state=directory owner=thumbp mode=0755
+  file: path=/var/log/thumbp state=directory owner=thumbp group=thumbp mode=0755 recurse=yes
 
 - name: Ensure state of opt directory
   file: path=/opt/thumbp state=directory owner=thumbp mode=0755


### PR DESCRIPTION
Fix an oversight in the `thumbp` role, where a re-created `thumbp` user account would result in `/var/log/thumbp/thumbp.log` no longer being writable after a "clean" deployment, which would cause `thumbp` not to be able to start again.  (Solution: recursively ensure log directory ownership.)

Introduce the `clean_rbenv` variable, which can be used to delete a Rails application's Rbenv in order to clean it out, or to recompile C extensions from scratch; useful, for example, after an o/s upgrade.