### PR TITLE
Fix failure of php-fpm to be respawned by upstart

### DIFF
--- a/ansible/roles/common_php/files/etc_init_php5-fpm.conf
+++ b/ansible/roles/common_php/files/etc_init_php5-fpm.conf
@@ -1,0 +1,30 @@
+# php5-fpm - The PHP FastCGI Process Manager
+
+description "The PHP FastCGI Process Manager"
+author "Ondřej Surý <ondrej@debian.org>"
+# Modified by Mark Breedlove, DPLA
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+# Precise upstart does not support reload signal, and thus rejects the
+# job. We'd rather start the daemon, instead of forcing users to
+# reboot https://bugs.launchpad.net/ubuntu/+source/php5/+bug/1272788
+#
+# reload signal USR2
+
+# Say that a normal exit status is either 0 (success) 1 (some error with the
+# configuration, probably), or when the master is explicitly stopped
+# (TERM / INT). These are the conditions under which the daemon will _not_ be
+# respawned.  If the master is killed by a SIGKILL or something else like a
+# segfault, we do want to respawn it!
+normal exit 0 1 TERM INT
+
+pre-start exec /usr/lib/php5/php5-fpm-checkconf
+# Kill child processes that may be running if the master was killed earlier with
+# SIGKILL. These will have the socket files open and prevent php-fpm from
+# starting.
+pre-start exec sh -c "pkill php || true"
+
+respawn
+exec /usr/sbin/php5-fpm --nodaemonize --fpm-config /etc/php5/fpm/php-fpm.conf

--- a/ansible/roles/common_php/tasks/main.yml
+++ b/ansible/roles/common_php/tasks/main.yml
@@ -62,3 +62,14 @@
   tags:
     - web
     - php
+
+- name: Install improved upstart init configuration file
+  copy:
+    src: etc_init_php5-fpm.conf
+    dest: /etc/init/php5-fpm.conf
+    mode: 0644
+    owner: root
+    group: root
+  tags:
+    - web
+    - php


### PR DESCRIPTION
The upstart (init) configuration file for the php5-fpm package in Ubuntu 14 fails to respawn the php-fpm master process when it's killed with SIGKILL or (presumably) segfaults or dies due to some other reason.

For our purposes, we only want a SIGTERM or maybe SIGINT to be considered an intentional stop signal that signifies success. We also want to make sure that stale child processes are killed off before trying to restart php-fpm, because they'll be holding on to the socket files, preventing the service from starting.

This fixes https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1230