### PR TITLE
Add Universal Viewer

### DIFF
--- a/ansible/development
+++ b/ansible/development
@@ -44,6 +44,9 @@ dbnodes
 [thumbp:children]
 webapps
 
+[uv:children]
+webapps
+
 [development]
 loadbal
 dbnode1

--- a/ansible/playbooks/dev_webapps.yml
+++ b/ansible/playbooks/dev_webapps.yml
@@ -41,6 +41,7 @@
   roles:
     - frontend
     - { role: thumbp, tags: ['thumbp']}
+    - { role: uv, tags: ['uv']}
   vars:
     level: development
     do_deployment: true

--- a/ansible/playbooks/uv.yml
+++ b/ansible/playbooks/uv.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Gather inventory facts in case playbook is run standalone
+  hosts: all
+
+- name: Universal Viewer
+  hosts: uv
+  serial: 1
+  become: yes
+  vars:
+    do_deployment: yes
+  roles:
+    - { role: uv, tags: ['uv']}

--- a/ansible/playbooks/uv_development.yml
+++ b/ansible/playbooks/uv_development.yml
@@ -1,0 +1,3 @@
+---
+
+- include: uv.yml level=development

--- a/ansible/playbooks/uv_production.yml
+++ b/ansible/playbooks/uv_production.yml
@@ -1,0 +1,3 @@
+---
+
+- include: uv.yml level=production

--- a/ansible/playbooks/uv_staging.yml
+++ b/ansible/playbooks/uv_staging.yml
@@ -1,0 +1,3 @@
+---
+
+- include: uv.yml level=staging

--- a/ansible/production_all.yml
+++ b/ansible/production_all.yml
@@ -54,6 +54,8 @@
   become: yes
   roles:
     - {role: frontend, tags: ['frontend']}
+    - {role: uv, tags: ['uv']}
+    - {role: thumbp, tags: ['thumbp']}
   vars:
     level: production
     skip_configuration: no

--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -48,6 +48,8 @@ if [ $? -ne 0 ]; then
 fi
 rbenv rehash
 
+echo "cleaning assets ..." >> $LOGFILE
+bundle exec rake assets:clean >> $LOGFILE 2>&1 || exit 1
 echo "precompiling assets ..." >> $LOGFILE
 bundle exec rake assets:precompile >> $LOGFILE 2>&1 || exit 1
 

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -453,6 +453,10 @@ server {
     }
 {% endif %}
 
+    location /uv/ {
+        alias /srv/www/uv/;
+    }
+
     location /wiki {
         return 301 http://web.archive.org/web/20160316200044/http://dp.la/wiki/Main_Page;
      }

--- a/ansible/roles/uv/defaults/main.yml
+++ b/ansible/roles/uv/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+
+uv_nvm_version: 0.33.1
+uv_node_version: 0.12.7
+uv_use_local_source: false
+uv_branch_or_tag: v2.0.1
+# uv_dist_dir and uv_branch_or_tag could be generated from a base version
+# number, but specifying them separately like this should make it easier to
+# work either with git checkouts or local development working copies.
+# See the role's deploy.yml and the site_proxy role's NGINX configuration.
+uv_dist_dir: uv-2.0.1

--- a/ansible/roles/uv/files/build_uv.sh
+++ b/ansible/roles/uv/files/build_uv.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+node_version=$1
+log=/tmp/build_uv.log
+src_dir=/opt/uv/src/universalviewer
+export NVM_DIR="/opt/uv/.nvm"
+
+. $NVM_DIR/nvm.sh  # necessary?  It's already in `uv' user's .bashrc
+
+echo "Starting at `date`" > $log
+
+
+cd $src_dir || exit_w_error "Can not cd to $src_dir"
+
+exit_w_error() {
+    echo >&2 $1
+    echo $1 >> $log
+    exit 1
+}
+
+echo "Ensuring correct version of Node" | tee -a $log
+nvm install $node_version || exit_w_error "nvm install failed"
+
+echo "Making sure that Grunt is installed." | tee -a $log
+npm install grunt-cli || exit_w_error "could not install Grunt"
+
+echo "Making sure that Bower is installed." | tee -a $log
+npm install bower || exit_w_error "could not install Bower"
+
+src_modules_dir=$src_dir/node_modules
+export PATH=$src_modules_dir/grunt-cli/bin:$src_modules_dir/bower/bin:$PATH
+
+echo "Installing packages ..." | tee -a $log
+
+npm install || exit_w_error "'npm install' failed"
+bower install || exit_w_error "'bower install' failed"
+grunt sync || exit_w_error "'grunt sync' failed"
+
+echo "... done" | tee -a $log
+
+echo "rsyncing ..." | tee -a $log
+/usr/bin/rsync -rIptolg --checksum --delete --delay-updates \
+    --exclude '.git' \
+    $src_dir/ /opt/uv/universalviewer
+if [ $? -ne 0 ]; then
+    exit_w_error "rsync failed"
+fi
+
+echo "Success" | tee -a $log
+exit 0

--- a/ansible/roles/uv/files/copy_local_app.sh
+++ b/ansible/roles/uv/files/copy_local_app.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ ! -d /universalviewer ]; then
+    >&2 echo "Local directory /universalviewer does not exist (check Vagrantfile)"
+    exit 1
+fi
+
+rsync -rIptl --delete --checksum --exclude '.git*' \
+    /universalviewer/ /opt/uv/src/universalviewer-local

--- a/ansible/roles/uv/tasks/clean.yml
+++ b/ansible/roles/uv/tasks/clean.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Remove directories
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /opt/uv/.nvm
+    - /opt/uv/.npm
+    - /opt/uv/universalviewer
+    - /opt/uv/src

--- a/ansible/roles/uv/tasks/deploy.yml
+++ b/ansible/roles/uv/tasks/deploy.yml
@@ -1,0 +1,44 @@
+---
+
+- name: Clear symlink
+  file: path=/opt/uv/src/universalviewer state=absent
+
+- name: Check out Universal Viewer from repository
+  when: not uv_use_local_source
+  become_user: uv
+  git:
+    repo: https://github.com/UniversalViewer/universalviewer.git
+    dest: /opt/uv/src/universalviewer-git
+    version: "{{ uv_branch_or_tag }}"
+    force: true
+
+- name: Sync Universal Viewer from mounted directory (using local source)
+  when: uv_use_local_source
+  become_user: uv
+  script: copy_local_app.sh
+  register: script_result
+  changed_when: "'Success: changed' in script_result.stdout"
+
+- name: Symlink git working copy
+  file:
+    src: /opt/uv/src/universalviewer-git
+    dest: /opt/uv/src/universalviewer
+    state: link
+  when: not uv_use_local_source
+- name: Symlink copied local directory
+  file:
+    src: /opt/uv/src/universalviewer-local
+    dest: /opt/uv/src/universalviewer
+    state: link
+  when: uv_use_local_source
+
+- name: Build uv and sync to installation directory
+  become_user: uv
+  script: "build_uv.sh {{ uv_node_version }}"
+
+- name: Ensure that the symlink for the NGINX `location' is correct
+  # See site_proxy role, etc_nginx_sites_available_site-proxy.j2
+  file:
+    src: "/opt/uv/universalviewer/dist/{{ uv_dist_dir }}"
+    dest: /srv/www/uv
+    state: link

--- a/ansible/roles/uv/tasks/main.yml
+++ b/ansible/roles/uv/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+
+- include: clean.yml
+  when: clean_uv | default(false)
+
+- name: Ensure existence of the "uv" account
+  user:
+    name: uv
+    comment: "Universal Viewer privsep user"
+    home: /opt/uv
+    shell: /bin/bash
+    state: present
+  tags:
+    - users
+
+- name: Ensure state of installation directory
+  file: path=/opt/uv/universalviewer state=directory owner=uv mode=0755
+
+- name: Ensure state of source directory
+  file: path=/opt/uv/src state=directory owner=uv mode=0755
+
+- name: Ensure state of source subdirectories
+  file:
+    path: "/opt/uv/src/{{ item }}"
+    state: directory
+    owner: uv
+    mode: 0755
+  with_items:
+    - universalviewer-local
+    - universalviewer-git
+
+- name: Make sure that Node Version Manager is installed
+  become_user: uv
+  script: "../../../files/install_nvm.sh {{ uv_nvm_version }}"
+  register: script_result
+  changed_when: "'Success: changed' in script_result.stdout"
+
+- include: deploy.yml
+  when: do_deployment

--- a/ansible/staging_all.yml
+++ b/ansible/staging_all.yml
@@ -53,6 +53,8 @@
   serial: 1
   roles:
     - {role: frontend, tags: ['frontend']}
+    - {role: uv, tags: ['uv']}
+    - {role: thumbp, tags: ['thumbp']}
   vars:
     level: staging
     skip_configuration: no


### PR DESCRIPTION
Add `uv` role for Universal Viewer, and update NGINX configuration to serve the Javascript under `/uv`.

This changeset interacts with ongoing changes being made in the `frontend` app, so it shouldn't be merged until everything is synced up between `automation` and `frontend`.

To test, try running the role in your development VMs. You can run `ansible-playbook` like this:
```
ansible-playbook -u <you> -i development playbooks/dev_webapps.yml -e 'level=development'
```
If you need to deploy it again from scratch you can run the same playbook with `-e 'level=development clean_uv=true' -t uv` and save some time.

Let me know if you get an error from the `npm install` step in `build_uv.sh` saying "Fatal error in ../deps/v8/src/heap/store-buffer.cc" and "CHECK(object->IsHeapObject()) Failed".  This may be an out-of-memory issue that I need to fix. It's been intermittent for me; I've always found that running `npm install` again works when it fails the first time. This is something that needs to be resolved before this is merged, but I want to get this out in front of you in the meantime to work out the necessary integration with `frontend`.
