### PR TITLE
Two little fixes

### DIFF
--- a/ansible/roles/ec2_swapper/tasks/needs_swap.yml
+++ b/ansible/roles/ec2_swapper/tasks/needs_swap.yml
@@ -8,6 +8,9 @@
 # Instances that don't have Instance Store volumes will have the /swap
 # directory created on the root volume.
 
+- name: Ensure state of instance store mount point
+  file: path=/swap state=directory owner=root group=root mode=0755
+
 - name: Unmount instance store volume that EC2 automatically mounts
   mount: name=/mnt state=absent src=/dev/xvdb fstype=ext3
 

--- a/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
+++ b/ansible/roles/site_proxy/templates/etc_nginx_sites_available_site-proxy.j2
@@ -226,6 +226,7 @@ server {
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;
     proxy_set_header X-Forwarded-Proto "https";
+    proxy_set_header Host $host;
     {% endif %}
 
     # Bad bot!


### PR DESCRIPTION
Set Host HTTP header in site proxy NGINX configuration when the SSL site proxy is not behind a loadbalancer (`siteproxy_self_ssl`).  Otherwise, the Host ends up being `dpla_portal` because that's the name of the`upstream` specified by `proxy_pass`.

Add back the task in the `ec2_swapper` role that checks that the `/swap` directory exists. This was removed in 62631a563a30 with the assumption that a later `mount` task would ensure its existence; overlooking the fact that the `mount` task is not run on a t2 or m4 instance.

These two commits should not be squashed.
