### PR TITLE
Make separate accounts for applications

### DIFF
--- a/ansible/playbooks/init_index_and_repos.yml
+++ b/ansible/playbooks/init_index_and_repos.yml
@@ -28,7 +28,7 @@
     - name: Delete any existing river
       script: >
           ../files/delete_river.sh {{ api_rbenv_version }}
-      become_user: dpla
+      become_user: api
 
     - name: Drop existing repositories
       local_action: uri
@@ -64,17 +64,17 @@
     - name: Create api key database (with its design doc)
       script: >
           ../files/create_api_key_database.sh {{ api_rbenv_version }}
-      become_user: dpla
+      become_user: api
 
     - name: Create new index and river
       script: >
           ../files/create_index_and_river.sh {{ api_rbenv_version }}
-      become_user: dpla
+      become_user: api
 
     - name: Delete any undeployed indices
       script: >
           ../files/delete_undeployed_indices.sh {{ api_rbenv_version }}
-      become_user: dpla
+      become_user: api
 
     - name: Create test API user (optional)
       when: create_test_account is defined

--- a/ansible/roles/api/files/build_api.sh
+++ b/ansible/roles/api/files/build_api.sh
@@ -8,7 +8,7 @@ echo "starting" > $LOGFILE
 
 eval "`rbenv init -`"
 
-cd /home/dpla/api
+cd /home/api/api
 
 rbenv shell $USE_VERSION >> $LOGFILE 2>&1
 
@@ -23,7 +23,7 @@ echo "rsync from home to /srv/www/api ..." >> $LOGFILE
     --exclude 'var/log' \
     --exclude 'tmp' \
     --exclude '.git' \
-    /home/dpla/api/ /srv/www/api
+    /home/api/api/ /srv/www/api
 if [ $? -ne 0 ]; then
     exit 1
 fi
@@ -36,7 +36,7 @@ for dir in $dirs_to_check; do
     if [ ! -d $dir ]; then
         echo "... creating $dir"
         mkdir $dir \
-            && chown dpla:webapp $dir \
+            && chown api:webapp $dir \
             && chmod 0775 $dir
         if [ $? -ne 0 ]; then
             exit 1

--- a/ansible/roles/api/files/copy_local_app.sh
+++ b/ansible/roles/api/files/copy_local_app.sh
@@ -9,15 +9,15 @@ if [ ! -d /api_dev ]; then
 	exit 1
 fi
 
-if [ ! -d /home/dpla/api-local ]; then
-	mkdir /home/dpla/api-local
+if [ ! -d /home/api/api-local ]; then
+	mkdir /home/api/api-local
 fi
 
 rsync -rIptl --delete --checksum \
     --exclude 'var/log' --exclude 'tmp' --exclude 'vendor/bundle' \
-    /api_dev/ /home/dpla/api-local
+    /api_dev/ /home/api/api-local
 if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-chown -Rh dpla:dpla /home/dpla/api-local
+chown -Rh api:api /home/api/api-local

--- a/ansible/roles/api/tasks/deploy.yml
+++ b/ansible/roles/api/tasks/deploy.yml
@@ -2,13 +2,13 @@
 
 # Clear these out prior to copying and symlinking below
 
-- name: Clear /home/dpla/api symlink
-  file: path=/home/dpla/api state=absent
+- name: Clear /home/api/api symlink
+  file: path=/home/api/api state=absent
 
 - name: Make sure that API build directories are clear
   when: clean_api | default(false)
   file:
-    path: "/home/dpla/{{ item }}"
+    path: "/home/api/{{ item }}"
     state: absent
   with_items:
     - api-git
@@ -17,15 +17,15 @@
 - name: Check out api (platform) app from its repository (git)
   git: >-
       repo="{{ api_repo }}"
-      dest=/home/dpla/api-git
+      dest=/home/api/api-git
       version={{ api_branch_or_tag | default("master") }}
       force=true
-  become_user: dpla
+  become_user: api
   when: not api_use_local_source
 
 # Symlink to the build directory, to allow local and git builds to coexist neatly
 # 1. Git deployment ...
-- file: src=/home/dpla/api-git dest=/home/dpla/api state=link
+- file: src=/home/api/api-git dest=/home/api/api state=link
   when: not api_use_local_source
 
 - name: Check out api (platform) app from mounted directory (local)
@@ -34,33 +34,39 @@
 
 # Symlink, as above
 # 2. Local filesystem deployment ...
-- file: src=/home/dpla/api-local dest=/home/dpla/api state=link
+- file: src=/home/api/api-local dest=/home/api/api state=link
   when: api_use_local_source
 
 - name: Update api app database configuration
   template: >
-      src=database.yml.j2 dest=/home/dpla/api/config/database.yml
-      owner=dpla group=webapp mode=0640
+      src=database.yml.j2 dest=/home/api/api/config/database.yml
+      owner=api group=webapp mode=0640
   when: not api_use_local_source
 
 - name: Update api app settings in v1
   template: >
-      src=dpla.yml.j2 dest=/home/dpla/api/v1/config/dpla.yml
-      owner=dpla group=webapp mode=0640
+      src=dpla.yml.j2 dest=/home/api/api/v1/config/dpla.yml
+      owner=api group=webapp mode=0640
   when: not api_use_local_source
 
 - name: Update api unicorn.rb
   template: >
-      src=unicorn.rb.j2 dest=/home/dpla/api/config/unicorn.rb
-      owner=dpla group=dpla mode=0644
+      src=unicorn.rb.j2 dest=/home/api/api/config/unicorn.rb
+      owner=api group=api mode=0644
 
 - name: Make sure rbenv and bundler are current
   script: >
       ../../../files/install_ruby_tools.sh {{ api_rbenv_version }}
-  become_user: dpla
+  become_user: api
 
 - name: Ensure existence of live app directory
-  file: path=/srv/www/api state=directory owner=dpla group=dpla mode=0755
+  file:
+    path: /srv/www/api
+    state: directory
+    owner: api
+    group: api
+    recurse: yes
+    mode: 0755
 
 - name: Stop Unicorn (gracefully)
   # Unicorn is stopped completely, and later restarted, because we assume that
@@ -81,7 +87,7 @@
 - name: Build api app
   script: >
       build_api.sh {{ api_rbenv_version }}
-  become_user: dpla
+  become_user: api
   notify:
     - restart memcached
 

--- a/ansible/roles/api/tasks/main.yml
+++ b/ansible/roles/api/tasks/main.yml
@@ -15,6 +15,23 @@
   tags:
     - packages
 
+- name: Ensure that "api" user exists
+  user:
+    name: api
+    comment: "API application user"
+    home: /home/api
+    shell: /bin/bash
+    groups: webapp
+    state: present
+  tags:
+    - users
+    - web
+
+- name: Ensure that "api" user's .ssh directory exists
+  file: path=/home/api/.ssh state=directory mode=0700 owner=api group=api
+  tags:
+    - users
+    - web
 
 ## Init scripts and control scripts
 #

--- a/ansible/roles/api/templates/delayed_job_api.sh.j2
+++ b/ansible/roles/api/templates/delayed_job_api.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-USERNAME="dpla"
+USERNAME="api"
 APP_ROOT="/srv/www/api"
 
 export RBENV_VERSION="{{ api_rbenv_version }}"

--- a/ansible/roles/api/templates/etc_init.d_delayed_job_api.j2
+++ b/ansible/roles/api/templates/etc_init.d_delayed_job_api.j2
@@ -10,7 +10,7 @@
 set -u
 set -e
 
-USERNAME="dpla"
+USERNAME="api"
 APP_NAME="api"
 APP_ROOT="/srv/www/api"
 CONTROL_SCRIPT="/usr/local/sbin/delayed_job_api.sh"

--- a/ansible/roles/api/templates/etc_init.d_unicorn_api.j2
+++ b/ansible/roles/api/templates/etc_init.d_unicorn_api.j2
@@ -14,7 +14,7 @@ set -e
 
 . /lib/lsb/init-functions
 
-USERNAME="dpla"
+USERNAME="api"
 APP_NAME="api"
 APP_ROOT="/srv/www/api"
 START_SCRIPT="/usr/local/sbin/start_unicorn_api.sh"

--- a/ansible/roles/api/templates/start_unicorn_api.sh.j2
+++ b/ansible/roles/api/templates/start_unicorn_api.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-USERNAME="dpla"
+USERNAME="api"
 APP_ROOT="/srv/www/api"
 UNICORN_OPTS="-D -E {{ api_rails_env }} -c $APP_ROOT/config/unicorn.rb"
 

--- a/ansible/roles/api/templates/unicorn.rb.j2
+++ b/ansible/roles/api/templates/unicorn.rb.j2
@@ -5,7 +5,7 @@
 #
 # See http://unicorn.bogomips.org/Unicorn/Configurator.html for complete
 # documentation.
-user "dpla", "dpla"
+user "api", "api"
 
 # Use at least one worker per core if you're on a dedicated server,
 # more will usually help for _short_ waits on databases/caches.

--- a/ansible/roles/common_web/tasks/main.yml
+++ b/ansible/roles/common_web/tasks/main.yml
@@ -52,23 +52,9 @@
     - nginx
     - web
 
-- name: Ensure "dpla" user exists
-  user: >
-      name=dpla comment="DPLA application user"
-      home=/home/dpla shell=/bin/bash state=present
-  tags:
-    - users
-    - web
-
 - name: Ensure "webapp" group exists
   # For granting read access to configuration files
   group: name=webapp state=present
-  tags:
-    - users
-    - web
-
-- name: Ensure membership of "dpla" in "webapp" group
-  user: name=dpla groups=webapp
   tags:
     - users
     - web
@@ -79,11 +65,6 @@
     - users
     - web
 
-- name: Ensure dpla user's .ssh directory exists
-  file: path=/home/dpla/.ssh state=directory mode=0700 owner=dpla group=dpla
-  tags:
-    - users
-    - web
 
 - name: Ensure state of server-status configuration for monitoring
   template: >-

--- a/ansible/roles/frontend/files/build_frontend.sh
+++ b/ansible/roles/frontend/files/build_frontend.sh
@@ -63,7 +63,7 @@ echo "rsync home to /srv/www ..." >> $LOGFILE
     --exclude 'tmp' \
     --exclude '.git' \
     --exclude 'public/uploads' \
-    /home/dpla/frontend/ /srv/www/frontend
+    /home/frontend/frontend/ /srv/www/frontend
 if [ $? -ne 0 ]; then
     exit 1
 fi
@@ -78,7 +78,7 @@ echo "check logfile directory ..." >> $LOGFILE
 logdir='/srv/www/frontend/log'
 if [ ! -d $logdir ]; then
     mkdir $logdir \
-        && chown dpla:webapp $logdir \
+        && chown frontend:webapp $logdir \
         && chmod 0775 $logdir
     if [ $? -ne 0 ]; then
         exit 1

--- a/ansible/roles/frontend/files/copy_local_app.sh
+++ b/ansible/roles/frontend/files/copy_local_app.sh
@@ -9,16 +9,16 @@ if [ ! -d /frontend_dev ]; then
 	exit 1
 fi
 
-if [ ! -d /home/dpla/frontend-local ]; then
-	mkdir /home/dpla/frontend-local
+if [ ! -d /home/frontend/frontend-local ]; then
+	mkdir /home/frontend/frontend-local
 fi
 
 rsync -rIptl --delete --checksum \
     --exclude 'log' --exclude 'tmp' --exclude 'vendor/assets' \
     --exclude 'public/assets' --exclude 'public/uploads' \
-    /frontend_dev/ /home/dpla/frontend-local
+    /frontend_dev/ /home/frontend/frontend-local
 if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-chown -Rh dpla:dpla /home/dpla/frontend-local
+chown -Rh frontend:frontend /home/frontend/frontend-local

--- a/ansible/roles/frontend/tasks/deploy.yml
+++ b/ansible/roles/frontend/tasks/deploy.yml
@@ -1,13 +1,13 @@
 ---
 
-- name: Clear /home/dpla/frontend symlink
+- name: Clear /home/frontend/frontend symlink
   # It will be recreated below
-  file: path=/home/dpla/frontend state=absent
+  file: path=/home/frontend/frontend state=absent
 
 - name: Make sure that frontend build directories are clear
   when: clean_frontend | default(false)
   file:
-    path: "/home/dpla/{{ item }}"
+    path: "/home/frontend/{{ item }}"
     state: absent
   with_items:
     - frontend-git
@@ -16,15 +16,15 @@
 - name: Check out frontend app from its repository
   git: >-
       repo=https://github.com/dpla/frontend.git
-      dest=/home/dpla/frontend-git
+      dest=/home/frontend/frontend-git
       version={{ frontend_branch_or_tag }}
       force=true
-  become_user: dpla
+  become_user: frontend
   when: not frontend_use_local_source
 
 # Symlink to the build directory, to allow local and git builds to coexist neatly
 # 1. For a git deployment ...
-- file: src=/home/dpla/frontend-git dest=/home/dpla/frontend state=link
+- file: src=/home/frontend/frontend-git dest=/home/frontend/frontend state=link
   when: not frontend_use_local_source
 
 - name: Check out frontend app from mounted directory
@@ -33,29 +33,29 @@
 
 # Symlink (see above)
 # 2. For a local deployment ...
-- file: src=/home/dpla/frontend-local dest=/home/dpla/frontend state=link
+- file: src=/home/frontend/frontend-local dest=/home/frontend/frontend state=link
   when: frontend_use_local_source
 
 - name: Update frontend app database configuration
   template: >
-      src=database.yml.j2 dest=/home/dpla/frontend/config/database.yml
-      owner=dpla group=webapp mode=0640
+      src=database.yml.j2 dest=/home/frontend/frontend/config/database.yml
+      owner=frontend group=webapp mode=0640
   when: not frontend_use_local_source
 
 - name: Update frontend app settings
   template: >
-      src=settings.local.yml.j2 dest=/home/dpla/frontend/config/settings.local.yml
-      owner=dpla group=webapp mode=0640
+      src=settings.local.yml.j2 dest=/home/frontend/frontend/config/settings.local.yml
+      owner=frontend group=webapp mode=0640
   when: not frontend_use_local_source
 
 - name: Update frontend unicorn.rb
   template: >
-      src=unicorn.rb.j2 dest=/home/dpla/frontend/config/unicorn.rb
-      owner=dpla group=dpla mode=0644
+      src=unicorn.rb.j2 dest=/home/frontend/frontend/config/unicorn.rb
+      owner=frontend group=frontend mode=0644
 
 - name: Add dpla_frontend_assets to Gemfile if branding is turned on
   lineinfile: >
-    dest=/home/dpla/frontend/Gemfile
+    dest=/home/frontend/frontend/Gemfile
     state=present
     regexp=dpla_frontend_assets
     line="gem 'dpla_frontend_assets', git: 'git@github.com:dpla/frontend-assets.git'"
@@ -64,13 +64,19 @@
 - name: Make sure rbenv and bundler are current
   script: >
       ../../../files/install_ruby_tools.sh {{ frontend_rbenv_version }}
-  become_user: dpla
+  become_user: frontend
 
 - name: Ensure existence of live app directory
-  file: path=/srv/www/frontend state=directory owner=dpla group=dpla mode=0755
+  file:
+    path: /srv/www/frontend
+    state: directory
+    owner: frontend
+    group: frontend
+    recurse: yes
+    mode: 0755
 
 - name: Ensure existence of frontend/tmp directory
-  file: path=/srv/www/frontend/tmp state=directory owner=dpla group=dpla mode=0755
+  file: path=/srv/www/frontend/tmp state=directory owner=frontend group=frontend mode=0755
 
 # Krazy hijinx ensue to get around having a private GitHub repo for the frontend
 # assets gem...
@@ -79,8 +85,8 @@
   # This will be used by build_frontend.sh
   copy: >
       src={{ github_private_key_path | default("~/.ssh/id_rsa") }}
-      dest=/home/dpla/git_private_key
-      owner=dpla group=dpla mode=0600
+      dest=/home/frontend/git_private_key
+      owner=frontend group=frontend mode=0600
   when: frontend_include_branding
 
 - name: Stop Unicorn (gracefully)
@@ -103,17 +109,17 @@
   script: >-
       build_frontend.sh {{ frontend_rbenv_version }}
       {{ 'branding' if frontend_include_branding else '' }}
-  become_user: dpla
+  become_user: frontend
   notify: restart memcached
 
 - name: Ensure existence of uploads directory
   file: >-
       path=/srv/www/frontend/public/uploads state=directory
-      owner=dpla group=dpla mode=0755 recurse=yes
+      owner=frontend group=frontend mode=0755 recurse=yes
 
 - name: Start Unicorn
   service: name=unicorn_frontend state=started
 
 - name: Remove temporary private key for GitHub
-  file: path=/home/dpla/git_private_key state=absent
+  file: path=/home/frontend/git_private_key state=absent
   when: frontend_include_branding

--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -17,6 +17,24 @@
   tags:
     - packages
 
+- name: Ensure that "frontend" user exists
+  user:
+    name: frontend
+    comment: "frontend application user"
+    home: /home/frontend
+    shell: /bin/bash
+    groups: webapp
+    state: present
+  tags:
+    - users
+    - web
+
+- name: Ensure that "frontend" user's .ssh directory exists
+  file: path=/home/frontend/.ssh state=directory mode=0700 owner=frontend group=frontend
+  tags:
+    - users
+    - web
+
 - name: Ensure state of ImageMagick policy.xml file
   copy:
     src: ../../../files/imagemagick_policy.xml

--- a/ansible/roles/frontend/templates/etc_init.d_unicorn_frontend.j2
+++ b/ansible/roles/frontend/templates/etc_init.d_unicorn_frontend.j2
@@ -14,7 +14,7 @@ set -e
 
 . /lib/lsb/init-functions
 
-USERNAME="dpla"
+USERNAME="frontend"
 APP_NAME="frontend"
 APP_ROOT="/srv/www/frontend"
 START_SCRIPT="/usr/local/sbin/start_unicorn_frontend.sh"

--- a/ansible/roles/frontend/templates/start_unicorn_frontend.sh.j2
+++ b/ansible/roles/frontend/templates/start_unicorn_frontend.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-USERNAME="dpla"
+USERNAME="frontend"
 APP_ROOT="/srv/www/frontend"
 ENV={{ frontend_rails_env }}
 UNICORN_OPTS="-D -E $ENV -c $APP_ROOT/config/unicorn.rb"

--- a/ansible/roles/frontend/templates/unicorn.rb.j2
+++ b/ansible/roles/frontend/templates/unicorn.rb.j2
@@ -5,7 +5,7 @@
 #
 # See http://unicorn.bogomips.org/Unicorn/Configurator.html for complete
 # documentation.
-user "dpla", "dpla"
+user "frontend", "frontend"
 
 # Use at least one worker per core if you're on a dedicated server,
 # more will usually help for _short_ waits on databases/caches.

--- a/ansible/roles/omeka/files/build_exhibitions.sh
+++ b/ansible/roles/omeka/files/build_exhibitions.sh
@@ -10,7 +10,7 @@ echo "rsync home to /srv/www ..." >> $LOGFILE
     --exclude 'application/logs' \
     --exclude 'files' \
     --exclude 'plugins/Dropbox/files' \
-    /home/dpla/exhibitions/ /srv/www/exhibitions
+    /home/omeka/exhibitions/ /srv/www/exhibitions
 
 if [ $? -ne 0 ]; then
 	exit 1
@@ -18,6 +18,6 @@ fi
 
 echo "rsync exhibitions-assets ..." >> $LOGFILE
 /usr/bin/rsync -rIptolgC --delete --checksum --delay-updates \
-    /home/dpla/exhibitions-assets/ /srv/www/exhibitions/themes/dpla/exhibitions-assets
+    /home/omeka/exhibitions-assets/ /srv/www/exhibitions/themes/dpla/exhibitions-assets
 
 echo "done." >> $LOGFILE

--- a/ansible/roles/omeka/files/copy_local_app.sh
+++ b/ansible/roles/omeka/files/copy_local_app.sh
@@ -2,22 +2,22 @@
 
 # Run as root.
 # Copies directory owned by `vagrant' into directory owned
-# by `dpla'
+# by `omeka'
 
 if [ ! -d /exhibitions_dev ]; then
   echo "Local directory /exhibitions_dev does not exist" >&2
   exit 1
 fi
 
-if [ ! -d /home/dpla/exhibitions-local ]; then
-  mkdir /home/dpla/exhibitions-local
+if [ ! -d /home/omeka/exhibitions-local ]; then
+  mkdir /home/omeka/exhibitions-local
 fi
 
 rsync -rIptl --delete --checksum \
     --exclude 'application/logs' \
-    /exhibitions_dev/ /home/dpla/exhibitions-local
+    /exhibitions_dev/ /home/omeka/exhibitions-local
 if [ $? -ne 0 ]; then
   exit 1
 fi
 
-chown -Rh dpla:dpla /home/dpla/exhibitions-local
+chown -Rh omeka:omeka /home/omeka/exhibitions-local

--- a/ansible/roles/omeka/tasks/deploy.yml
+++ b/ansible/roles/omeka/tasks/deploy.yml
@@ -1,20 +1,20 @@
 ---
 
 # Clear this out prior to copying and symlinking below
-- file: path=/home/dpla/exhibitions state=absent
+- file: path=/home/omeka/exhibitions state=absent
 
 - name: Check out exhibitions app from its repository (git)
   git: >-
       repo=https://github.com/dpla/exhibitions.git
-      dest=/home/dpla/exhibitions-git
+      dest=/home/omeka/exhibitions-git
       version={{ exhibitions_branch_or_tag | default("master") }}
       force=true
-  become_user: dpla
+  become_user: omeka
   when: not exhibitions_use_local_source
 
 # Symlink to the build directory, to allow local and git builds to coexist neatly
 # 1. For a git deployment ...
-- file: src=/home/dpla/exhibitions-git dest=/home/dpla/exhibitions state=link
+- file: src=/home/omeka/exhibitions-git dest=/home/omeka/exhibitions state=link
   when: not exhibitions_use_local_source
 
 - name: Check out exhibitions app from mounted directory
@@ -23,30 +23,30 @@
 
 # Symlink (see above)
 # 2. For a local deployment ...
-- file: src=/home/dpla/exhibitions-local dest=/home/dpla/exhibitions state=link
+- file: src=/home/omeka/exhibitions-local dest=/home/omeka/exhibitions state=link
   when: exhibitions_use_local_source
 
 - name: Update exhibitions app database configuration file
   template: >
-      src=db.ini.j2 dest=/home/dpla/exhibitions/db.ini
-      owner=dpla group=webapp mode=0640
+      src=db.ini.j2 dest=/home/omeka/exhibitions/db.ini
+      owner=omeka group=webapp mode=0640
 
 - name: Update exhibitions app main configuration file
   template: >
       src=application_config_config.ini.j2
-      dest=/home/dpla/exhibitions/application/config/config.ini
-      owner=dpla group=webapp mode=0640
+      dest=/home/omeka/exhibitions/application/config/config.ini
+      owner=omeka group=webapp mode=0640
 
 - name: Check out exhibitions assets
   git: >-
        repo=https://github.com/dpla/exhibitions-assets.git
-       dest="/home/dpla/exhibitions-assets"
+       dest="/home/omeka/exhibitions-assets"
        version=master
        force=true
-  become_user: dpla
+  become_user: omeka
 
 - name: Ensure exhibitions document root exists
-  file: path=/srv/www/exhibitions state=directory owner=dpla group=dpla mode=0755
+  file: path=/srv/www/exhibitions state=directory owner=omeka group=omeka mode=0755
 
 - name: Build the exhibitions app
   script: build_exhibitions.sh
@@ -64,7 +64,7 @@
 - name: Ensure existence of "files" base directory
   file: >
       path="/srv/www/exhibitions/files" state=directory
-      mode=0755 owner=dpla group=dpla
+      mode=0755 owner=omeka group=omeka
 
 - name: Ensure existence of "files" subdirectories
   file: >

--- a/ansible/roles/omeka/tasks/main.yml
+++ b/ansible/roles/omeka/tasks/main.yml
@@ -1,5 +1,23 @@
 ---
 
+- name: Ensure that "omeka" user exists
+  user:
+    name: omeka
+    comment: "Omeka application user"
+    home: /home/omeka
+    shell: /bin/bash
+    groups: webapp
+    state: present
+  tags:
+    - users
+    - web
+
+- name: Ensure that "omeka" user's .ssh directory exists
+  file: path=/home/omeka/.ssh state=directory mode=0700 owner=omeka group=omeka
+  tags:
+    - users
+    - web
+
 - name: Ensure full installation of Imagemagick
   apt: pkg=imagemagick state=present
   when: not skip_configuration

--- a/ansible/roles/pss/files/build_pss.sh
+++ b/ansible/roles/pss/files/build_pss.sh
@@ -16,7 +16,7 @@ if [ "$BRANDING" == "branding" ]; then
     ssh-add $HOME/git_private_key
 fi
 
-cd /home/dpla/pss
+cd /home/pss/pss
 
 rbenv shell $USE_VERSION
 
@@ -45,7 +45,7 @@ echo "rsync from home to /srv/www/pss ..." >> $LOGFILE
     --exclude 'tmp' \
     --exclude '.git' \
     --exclude 'public/uploads' \
-    /home/dpla/pss/ /srv/www/pss
+    /home/pss/pss/ /srv/www/pss
 if [ $? -ne 0 ]; then
     exit 1
 fi

--- a/ansible/roles/pss/files/copy_local_app.sh
+++ b/ansible/roles/pss/files/copy_local_app.sh
@@ -2,24 +2,24 @@
 
 # Run as root.
 # Copies directory owned by `vagrant' into directory owned
-# by `dpla'
+# by `pss'
 
 if [ ! -d /pss_dev ]; then
 	echo "Local directory /pss_dev does not exist" >&2
 	exit 1
 fi
 
-if [ ! -d /home/dpla/pss-local ]; then
-	mkdir /home/dpla/pss-local
+if [ ! -d /home/pss/pss-local ]; then
+	mkdir /home/pss/pss-local
 fi
 
 rsync -rIptl --delete --checksum \
     --exclude 'log' --exclude 'tmp' \
     --exclude 'public/uploads' \
-    --exclude '.vagrant'
-    /pss_dev/ /home/dpla/pss-local
+    --exclude '.vagrant' \
+    /pss_dev/ /home/pss/pss-local
 if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-chown -Rh dpla:dpla /home/dpla/pss-local
+chown -Rh pss:pss /home/pss/pss-local

--- a/ansible/roles/pss/tasks/deploy.yml
+++ b/ansible/roles/pss/tasks/deploy.yml
@@ -1,13 +1,13 @@
 ---
 
-- name: Clear /home/dpla/pss symlink
+- name: Clear /home/pss/pss symlink
   # It will be recreated below.
-  file: path=/home/dpla/pss state=absent
+  file: path=/home/pss/pss state=absent
 
 - name: Make sure that PSS build directories are clear
   when: clean_pss | default(false)
   file:
-    path: "/home/dpla/{{ item }}"
+    path: "/home/pss/{{ item }}"
     state: absent
   with_items:
     - pss-git
@@ -16,17 +16,17 @@
 - name: Check out primary-source-sets app from its repository
   git: >-
       repo=https://github.com/dpla/primary-source-sets.git
-      dest=/home/dpla/pss-git
+      dest=/home/pss/pss-git
       version={{ pss_branch_or_tag }}
       force=true
-  become_user: dpla
+  become_user: pss
   when: not pss_use_local_source
 
 ## Symlink to the build directory, to allow local and git builds to coexist
 # neatly ...
 
 # 1. For a git deployment ...
-- file: src=/home/dpla/pss-git dest=/home/dpla/pss state=link
+- file: src=/home/pss/pss-git dest=/home/pss/pss state=link
   when: not pss_use_local_source
 
 - name: Check out primary source sets app from mounted directory
@@ -34,13 +34,13 @@
   when: pss_use_local_source
 
 # 2. For a local deployment ...
-- file: src=/home/dpla/pss-local dest=/home/dpla/pss state=link
+- file: src=/home/pss/pss-local dest=/home/pss/pss state=link
   when: pss_use_local_source
 
 - name: Update primary-source-sets app configuration files
   template: >-
-    src="{{ item }}.j2" dest="/home/dpla/pss/config/{{ item }}"
-    owner=dpla group=dpla mode=0640
+    src="{{ item }}.j2" dest="/home/pss/pss/config/{{ item }}"
+    owner=pss group=pss mode=0640
   with_items:
     - database.yml
     - secrets.yml
@@ -49,18 +49,18 @@
 - name: Update primary-source-sets app settings
   template: >-
       src=settings.local.yml.j2
-      dest=/home/dpla/pss/config/settings.local.yml
-      owner=dpla group=webapp mode=0640
+      dest=/home/pss/pss/config/settings.local.yml
+      owner=pss group=webapp mode=0640
   when: not pss_use_local_source
 
 - name: Update primary-source-sets unicorn.rb
   template: >-
-      src=unicorn.rb.j2 dest=/home/dpla/pss/config/unicorn.rb
-      owner=dpla group=dpla mode=0644
+      src=unicorn.rb.j2 dest=/home/pss/pss/config/unicorn.rb
+      owner=pss group=pss mode=0644
 
 - name: Add dpla_frontend_assets to Gemfile if branding is turned on
   lineinfile: >
-    dest=/home/dpla/pss/Gemfile
+    dest=/home/pss/pss/Gemfile
     state=present
     regexp=dpla_frontend_assets
     line="gem 'dpla_frontend_assets', git: 'git@github.com:dpla/frontend-assets.git'"
@@ -69,11 +69,16 @@
 - name: Make sure that rbenv and bundler are current
   script: >-
       ../../../files/install_ruby_tools.sh {{ pss_rbenv_version }}
-  become_user: dpla
+  become_user: pss
 
 - name: Ensure the existence and permissions of necessary directories
-  file: >-
-    path="{{ item }}" state=directory owner=dpla group=dpla mode=0755
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: pss
+    group: pss
+    recurse: yes
+    mode: 0755
   with_items:
     - /srv/www/pss
     - /srv/www/pss/tmp
@@ -86,8 +91,8 @@
   # This will be used by build_pss.sh
   copy: >-
       src={{ github_private_key_path | default("~/.ssh/id_rsa") }}
-      dest=/home/dpla/git_private_key
-      owner=dpla group=dpla mode=0600
+      dest=/home/pss/git_private_key
+      owner=pss group=pss mode=0600
 
 - name: Stop Unicorn (gracefully)
   # Unicorn is stopped completely, and later restarted, because we assume that
@@ -109,17 +114,17 @@
   script: >-
     build_pss.sh "{{ pss_rbenv_version }}"
     {{ 'branding' if pss_include_branding else '' }}
-  become_user: dpla
+  become_user: pss
   environment:
     RAILS_ENV: "{{ pss_rails_env }}"
 
 - name: Ensure existence of uploads directory
   file: >-
       path=/srv/www/pss/public/uploads state=directory
-      owner=dpla group=dpla mode=0755 recurse=yes
+      owner=pss group=pss mode=0755 recurse=yes
 
 - name: Start Unicorn
   service: name=unicorn_pss state=started
 
 - name: Remove temporary private key for GitHub
-  file: path=/home/dpla/git_private_key state=absent
+  file: path=/home/pss/git_private_key state=absent

--- a/ansible/roles/pss/tasks/main.yml
+++ b/ansible/roles/pss/tasks/main.yml
@@ -1,5 +1,23 @@
 ---
 
+- name: Ensure that "pss" user exists
+  user:
+    name: pss
+    comment: "Primary Source Sets application user"
+    home: /home/pss
+    shell: /bin/bash
+    groups: webapp
+    state: present
+  tags:
+    - users
+    - web
+
+- name: Ensure that "pss" user's .ssh directory exists
+  file: path=/home/pss/.ssh state=directory mode=0700 owner=pss group=pss
+  tags:
+    - users
+    - web
+
 - name: Ensure existence of necessary PSS packages
   apt: >-
     pkg="{{ item }}" state=present

--- a/ansible/roles/pss/templates/etc_init.d_unicorn_pss.j2
+++ b/ansible/roles/pss/templates/etc_init.d_unicorn_pss.j2
@@ -14,7 +14,7 @@ set -e
 
 . /lib/lsb/init-functions
 
-USERNAME="dpla"
+USERNAME="pss"
 APP_NAME="pss"
 APP_ROOT="/srv/www/pss"
 START_SCRIPT="/usr/local/sbin/start_unicorn_pss.sh"

--- a/ansible/roles/pss/templates/start_unicorn_pss.sh.j2
+++ b/ansible/roles/pss/templates/start_unicorn_pss.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-USERNAME="dpla"
+USERNAME="pss"
 APP_ROOT="/srv/www/pss"
 ENV={{ pss_rails_env }}
 UNICORN_OPTS="-D -E $ENV -c $APP_ROOT/config/unicorn.rb"

--- a/ansible/roles/pss/templates/unicorn.rb.j2
+++ b/ansible/roles/pss/templates/unicorn.rb.j2
@@ -5,7 +5,7 @@
 #
 # See http://unicorn.bogomips.org/Unicorn/Configurator.html for complete
 # documentation.
-user "dpla", "dpla"
+user "pss", "pss"
 
 # Use at least one worker per core if you're on a dedicated server,
 # more will usually help for _short_ waits on databases/caches.

--- a/ansible/roles/wordpress/files/sync_to_siteroot.sh
+++ b/ansible/roles/wordpress/files/sync_to_siteroot.sh
@@ -7,4 +7,4 @@ $rsync -rIptogl --checksum --delete --delay-updates \
     --exclude 'wp-content/uploads' \
     --exclude 'wp-config.php' \
     --exclude '.git' \
-    /home/dpla/wordpress/ /srv/www/wordpress
+    /home/wordpress/wordpress/ /srv/www/wordpress

--- a/ansible/roles/wordpress/tasks/main.yml
+++ b/ansible/roles/wordpress/tasks/main.yml
@@ -1,24 +1,42 @@
 ---
 
+- name: Ensure that "wordpress" user exists
+  user:
+    name: wordpress
+    comment: "Wordpress application user"
+    home: /home/wordpress
+    shell: /bin/bash
+    groups: webapp
+    state: present
+  tags:
+    - users
+    - web
+
+- name: Ensure that "wordpress" user's .ssh directory exists
+  file: path=/home/wordpress/.ssh state=directory mode=0700 owner=wordpress group=wordpress
+  tags:
+    - users
+    - web
+
 - name: Prep for build with private repo (git)
   when: do_wordpress and do_deployment and not wp_theme_use_local_source
   copy: >
       src={{ github_private_key_path | default("~/.ssh/id_rsa") }}
-      dest=/home/dpla/git_private_key
-      owner=dpla group=dpla mode=0600
+      dest=/home/wordpress/git_private_key
+      owner=wordpress group=wordpress mode=0600
   tags:
     - web
 
 - name: Build Wordpress (local)
   when: do_wordpress and do_deployment and wp_theme_use_local_source
-  become_user: dpla
+  become_user: wordpress
   script: build_wordpress_local.sh
   tags:
     - web
 
 - name: Build Wordpress (remote)
   when: do_wordpress and do_deployment and not wp_theme_use_local_source
-  become_user: dpla
+  become_user: wordpress
   script: >-
       build_wordpress_remote.sh "{{ wp_branch_or_tag }}"
   tags:
@@ -26,19 +44,25 @@
 
 - name: Remove private key file
   when: do_wordpress and do_deployment and not wp_theme_use_local_source
-  file: path=/home/dpla/git_private_key state=absent
+  file: path=/home/wordpress/git_private_key state=absent
   tags:
     - web
 
 - name: Ensure existence of site root
-  file: path=/srv/www/wordpress state=directory owner=dpla group=dpla mode=0755
+  file:
+    path: /srv/www/wordpress
+    state: directory
+    owner: wordpress
+    group: wordpress
+    recurse: yes
+    mode: 0755
   when: do_wordpress and do_deployment
   tags:
     - web
 
 - name: Sync installation to site root
   script: sync_to_siteroot.sh
-  become_user: dpla
+  become_user: wordpress
   when: do_wordpress and do_deployment
   notify:
     - reload php5-fpm
@@ -56,7 +80,7 @@
 - name: Ensure state of Wordpress configuration file
   template: >
       src=wp-config.php.j2 dest=/srv/www/wordpress/wp-config.php
-      owner=dpla group=www-data mode=0640
+      owner=wordpress group=www-data mode=0640
   when: do_wordpress and do_deployment
   notify:
     - reload php5-fpm


### PR DESCRIPTION
Make separate o/s accounts for individual web applications, instead of having all of them use "dpla".

This improves our ability to keep deployments from interfering with one-another and to do "clean" deployments.