### PR TITLE
Have Exhibitions set specific session name

### DIFF
--- a/ansible/roles/omeka/templates/application_config_config.ini.j2
+++ b/ansible/roles/omeka/templates/application_config_config.ini.j2
@@ -119,7 +119,7 @@ log.sql = false
 ; default: ""
 ;
 ; If left blank, Omeka will automatically select a unique session name.
-session.name = ""
+session.name = "exhibitions"
 
 ; session.saveHandler
 ; Determines how session data will be saved.


### PR DESCRIPTION
Have the Exhibitions Omeka application use a specific name for its session cookie. This allows us to better control the forwarding and filtering of HTTP headers in a caching proxy (specifically, CloudFront).