### PR TITLE
Add jenkins

### DIFF
--- a/ansible/files/install_aws_cli.sh
+++ b/ansible/files/install_aws_cli.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Install or upgrade the AWS Command-Line Interface (CLI) Python package in a
+# Pyenv.
+
+usage() {
+    echo <<EOT
+
+install_aws_cli.sh <pyenv Python version>
+
+EOT
+}
+
+exit_w_error() {
+    echo >&2 $1
+    exit 1
+}
+
+if [ "x$1" == "x" ]; then
+    usage
+    exit_w_error "First argument is missing"
+fi
+
+env
+
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+
+if [ "x$PYENV_SHELL" == "x" ]; then
+    exit_w_error "Pyenv is not installed, or not activated."
+fi
+
+if [ -d $HOME/.pyenv/versions/$1 ]; then
+    export PYENV_VERSION=$1
+else
+    exit_w_error "Pyenv Python version $1 is not present."
+fi
+
+pip install -U awscli

--- a/ansible/files/install_python_tools.sh
+++ b/ansible/files/install_python_tools.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+USE_VERSION=$1
+
+cd $HOME
+
+if [ ! -d $HOME/.pyenv ]; then
+    git clone https://github.com/pyenv/pyenv.git $HOME/.pyenv && \
+        echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $HOME/.bashrc && \
+        echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> $HOME/.bashrc && \
+        echo 'eval "$(pyenv init -)"' >> $HOME/.bashrc
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+fi
+
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+
+if [ -d $HOME/.pyenv/versions/$USE_VERSION ]; then
+    export PYENV_VERSION=$USE_VERSION
+else
+    pyenv install $USE_VERSION
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+    export PYENV_VERSION=$USE_VERSION
+fi
+
+pyenv rehash

--- a/ansible/roles/jenkins/defaults/main.yml
+++ b/ansible/roles/jenkins/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+
+jenkins_version: 2.60.1
+# Get the sha256 checksum from
+# http://mirrors.jenkins.io/war-stable/<VERSION>/jenkins.war.sha256
+jenkins_sha256: 34fde424dde0e050738f5ad1e316d54f741c237bd380bd663a07f96147bb1390
+# Get the md5 sum by running 'md5' or 'md5sum' on the downloaded file (where
+# you the maintainer download it and check it before updating this variable)
+# In the future when we upgrade to Ansible 2+ we can just use the SHA256 hash
+# above because the 'stat' module will be able to do SHA256.
+jenkins_md5: 9e14790b2345bf673abb24224eee4d2c
+jenkins_python_version: 2.7.13
+jenkins_aws_region: us-east-1

--- a/ansible/roles/jenkins/files/etc_init.d_jenkins
+++ b/ansible/roles/jenkins/files/etc_init.d_jenkins
@@ -1,0 +1,283 @@
+#!/bin/bash
+# /etc/init.d/jenkins
+# debian-compatible jenkins startup script.
+# Amelia A Lewis <alewis@ibco.com>
+#
+### BEGIN INIT INFO
+# Provides:          jenkins
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start Jenkins at boot time
+# Description:       Controls Jenkins Automation Server
+### END INIT INFO
+
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+
+DESC="Jenkins Automation Server"
+NAME=jenkins
+SCRIPTNAME=/etc/init.d/$NAME
+
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+#DAEMON=$JENKINS_SH
+DAEMON=/usr/bin/daemon
+DAEMON_ARGS="--name=$NAME --inherit --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE"
+
+if [ -n "$UMASK" ]; then
+    DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
+fi
+
+SU=/bin/su
+
+# Exit if the package is not installed
+if [ ! -x "$DAEMON" ]; then
+    echo "daemon package not installed" >&2
+    exit 1
+fi
+
+# Exit if not supposed to run standalone
+if [ "$RUN_STANDALONE" = "false" ]; then
+    echo "Not configured to run standalone" >&2
+    exit 1
+fi
+
+# load environments
+if [ -r /etc/default/locale ]; then
+  . /etc/default/locale
+  export LANG LANGUAGE
+elif [ -r /etc/environment ]; then
+  . /etc/environment
+  export LANG LANGUAGE
+fi
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
+. /lib/lsb/init-functions
+
+# Make sure we run as root, since setting the max open files through
+# ulimit requires root access
+if [ `id -u` -ne 0 ]; then
+    echo "The $NAME init script can only be run as root"
+    exit 1
+fi
+
+
+check_tcp_port() {
+    local service=$1
+    local assigned=$2
+    local default=$3
+    local assigned_address=$4
+    local default_address=$5
+
+    if [ -n "$assigned" ]; then
+        port=$assigned
+    else
+        port=$default
+    fi
+
+    if [ -n "$assigned_address" ]; then
+        address=$assigned_address
+    else
+        address=$default_address
+    fi
+
+    count=`netstat --listen --numeric-ports | grep $address\:$port[[:space:]] | grep -c . `
+
+    if [ $count -ne 0 ]; then
+        echo "The selected $service port ($port) on address $address seems to be in use by another program "
+        echo "Please select another address/port combination to use for $NAME"
+        return 1
+    fi
+}
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+    # the default location is /var/run/jenkins/jenkins.pid but the parent directory needs to be created
+    mkdir `dirname $PIDFILE` > /dev/null 2>&1 || true
+    chown $JENKINS_USER `dirname $PIDFILE`
+    # Return
+    #   0 if daemon has been started
+    #   1 if daemon was already running
+    #   2 if daemon could not be started
+    $DAEMON $DAEMON_ARGS --running && return 1
+
+    # Verify that the jenkins port is not already in use, winstone does not exit
+    # even for BindException
+    check_tcp_port "http" "$HTTP_PORT" "8080" "$HTTP_HOST" "0.0.0.0" || return 2
+
+    # If the var MAXOPENFILES is enabled in /etc/default/jenkins then set the max open files to the
+    # proper value
+    if [ -n "$MAXOPENFILES" ]; then
+        [ "$VERBOSE" != no ] && echo Setting up max open files limit to $MAXOPENFILES
+        ulimit -n $MAXOPENFILES
+    fi
+
+    # notify of explicit umask
+    if [ -n "$UMASK" ]; then
+        [ "$VERBOSE" != no ] && echo Setting umask to $UMASK
+    fi
+
+    # --user in daemon doesn't prepare environment variables like HOME, USER, LOGNAME or USERNAME,
+    # so we let su do so for us now
+    $SU -l $JENKINS_USER --shell=/bin/bash -c "$DAEMON $DAEMON_ARGS -- $JAVA $JAVA_ARGS -jar $JENKINS_WAR $JENKINS_ARGS" || return 2
+}
+
+
+#
+# Verify that all jenkins processes have been shutdown
+# and if not, then do killall for them
+#
+get_running()
+{
+    return `ps -U $JENKINS_USER --no-headers -f | egrep -e '(java)' | grep -v defunct | grep -c . `
+}
+
+force_stop()
+{
+    get_running
+    if [ $? -ne 0 ]; then
+    killall -u $JENKINS_USER java daemon || return 3
+    fi
+}
+
+# Get the status of the daemon process
+get_daemon_status()
+{
+    $DAEMON $DAEMON_ARGS --running || return 1
+}
+
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+    # Return
+    #   0 if daemon has been stopped
+    #   1 if daemon was already stopped
+    #   2 if daemon could not be stopped
+    #   other if a failure occurred
+    get_daemon_status
+    case "$?" in
+    0)
+        $DAEMON $DAEMON_ARGS --stop || return 2
+        # wait for the process to really terminate
+        for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+            sleep 1
+            $DAEMON $DAEMON_ARGS --running || break
+        done
+        if get_daemon_status; then
+            force_stop || return 3
+        fi
+        ;;
+    *)
+        force_stop || return 3
+        ;;
+    esac
+
+    # Many daemons don't delete their pidfiles when they exit.
+    rm -f $PIDFILE
+    return 0
+}
+
+# Verify the process did in fact start successfully and didn't just bomb out
+do_check_started_ok() {
+    sleep 1
+    if [ "$1" -ne "0" ]; then return $1; fi
+    get_running
+    if [ "$?" -eq "0" ]; then
+        return 2
+    else
+        return 0
+    fi
+}
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting $DESC" "$NAME"
+    do_start
+    START_STATUS="$?"
+    do_check_started_ok "$START_STATUS"
+    case "$?" in
+        0|1) log_end_msg 0 ;;
+        2) log_end_msg 1 ; exit 7 ;;
+    esac
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC" "$NAME"
+    do_stop
+    case "$?" in
+        0|1) log_end_msg 0 ;;
+        2) log_end_msg 1 ; exit 100 ;;
+    esac
+    ;;
+  restart|force-reload)
+    #
+    # If the "reload" option is implemented then remove the
+    # 'force-reload' alias
+    #
+    log_daemon_msg "Restarting $DESC" "$NAME"
+    do_stop
+    case "$?" in
+      0|1)
+        do_start
+        START_STATUS="$?"
+        sleep 1
+        do_check_started_ok "$START_STATUS"
+        case "$?" in
+          0) log_end_msg 0 ;;
+          1) log_end_msg 1 ; exit 100 ;; # Old process is still running
+          *) log_end_msg 1 ; exit 100 ;; # Failed to start
+        esac
+        ;;
+      *)
+      # Failed to stop
+    log_end_msg 1
+    ;;
+    esac
+    ;;
+  status)
+    get_daemon_status
+    case "$?" in
+    0)
+        echo "$DESC is running with the pid `cat $PIDFILE`"
+        rc=0
+        ;;
+    *)
+        get_running
+        procs=$?
+        if [ $procs -eq 0 ]; then
+            echo -n "$DESC is not running"
+            if [ -f $PIDFILE ]; then
+                echo ", but the pidfile ($PIDFILE) still exists"
+                rc=1
+            else
+                echo
+                rc=3
+            fi
+
+        else
+            echo "$procs instances of jenkins are running at the moment"
+            echo "but the pidfile $PIDFILE is missing"
+            rc=0
+        fi
+
+        exit $rc
+        ;;
+    esac
+    ;;
+  *)
+    echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+    exit 3
+    ;;
+esac
+
+exit 0

--- a/ansible/roles/jenkins/files/etc_logrotate.d_jenkins
+++ b/ansible/roles/jenkins/files/etc_logrotate.d_jenkins
@@ -1,0 +1,9 @@
+/var/log/jenkins/jenkins.log {
+        weekly
+        copytruncate
+        missingok
+        rotate 14
+        compress
+        delaycompress
+        notifempty
+}

--- a/ansible/roles/jenkins/handlers/main.yml
+++ b/ansible/roles/jenkins/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: restart jenkins
+  service: name=jenkins state=restarted

--- a/ansible/roles/jenkins/tasks/main.yml
+++ b/ansible/roles/jenkins/tasks/main.yml
@@ -1,0 +1,149 @@
+---
+
+- name: Ensure Java 8 runtime and 'daemon' installations
+  # Java 8 is available on Ubuntu 16.04 LTS (xenial), not 14.04 LTS (trusty)
+  apt:
+    pkg: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - openjdk-8-jdk
+    - daemon
+
+- name: Ensure existence of 'jenkins' account
+  user:
+    name: jenkins
+    comment: "Jenkins application user"
+    home: /home/jenkins
+    shell: /bin/bash
+    state: present
+
+- name: Ensure state of /opt/jenkins
+  file:
+    path: /opt/jenkins
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Ensure state of jenkins-owned directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: jenkins
+    group: jenkins
+    recurse: yes
+  with_items:
+    - /opt/jenkins/jenkins_home
+    - /var/log/jenkins
+    - /var/run/jenkins
+    - /var/cache/jenkins
+
+- name: Gather information on the Jenkins WAR file
+  stat: path=/opt/jenkins/jenkins.war get_md5=yes
+  register: jenkins_war
+  changed_when: false
+
+# FIXME: When we upgrade to Ansible 2+ we can just use the SHA256 for both of
+# the checksums because the 'stat' module above will support it.
+- name: Download Jenkins WAR
+  get_url:
+    url: "http://mirrors.jenkins.io/war-stable/{{ jenkins_version }}/jenkins.war"
+    dest: /opt/jenkins/jenkins.war
+    sha256sum: "{{ jenkins_sha256 }}"
+    owner: root
+    group: root
+    mode: 0644
+  when: >-
+    not jenkins_war.stat.exists or jenkins_war.stat.md5 != '{{ jenkins_md5 }}'
+  notify: restart jenkins
+
+- name: Ensure state of /etc/default/jenkins default variables file
+  template:
+    src: etc_default_jenkins.j2
+    dest: /etc/default/jenkins
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart jenkins
+
+- name: Ensure state of Jenkins init script
+  copy:
+    src: etc_init.d_jenkins
+    dest: /etc/init.d/jenkins
+    owner: root
+    group: root
+    mode: 0755
+  notify: restart jenkins
+
+- name: Ensure Jenkins init run levels
+  command: update-rc.d jenkins defaults
+
+- name: Ensure state of Jenkins logrotate configuration file
+  copy:
+    src: etc_logrotate.d_jenkins
+    dest: /etc/logrotate.d/jenkins
+    owner: root
+    group: root
+    mode: 0644
+
+# A first-time installation of Jenkins requires some administrator involvement
+# to set the initial admin account and password and select plugins.  That will
+# not be automated here.  Please follow the instructions in the Jenkins web
+# interface on port 8080 of the server.
+
+- name: Ensure that necessary build-related packages are installed
+  apt:
+    pkg: "{{ item }}"
+    update_cache: yes
+    state: present
+  with_items:
+    - git
+    - libreadline-dev
+    - libsqlite3-dev
+    - libssl-dev
+    - libbz2-dev
+    - make
+    - build-essential
+    - zlib1g-dev
+    - wget
+    - curl
+    - llvm
+    - libncurses5-dev
+    - libncursesw5-dev
+    - xz-utils
+    - tk-dev
+
+- name: Ensure that pyenv is installed for 'jenkins' account
+  # The 'jenkins' user is created above, and we prefer to install Python
+  # packages like Ansible with pyenv.
+  become_user: jenkins
+  script: >-
+    ../../../files/install_python_tools.sh {{ jenkins_python_version }}
+
+- name: Ensure that the latest version of the AWS CLI is installed
+  become_user: jenkins
+  script: >-
+    ../../../files/install_aws_cli.sh {{ jenkins_python_version }}
+
+- name: Ensure state of AWS CLI configuration directory
+  file:
+    path: /home/jenkins/.aws
+    state: directory
+    owner: jenkins
+    group: jenkins
+    mode: 0750
+
+- name: Ensure state of AWS CLI configuration file
+  template:
+    src: aws_config.j2
+    dest: /home/jenkins/.aws/config
+    owner: jenkins
+    group: jenkins
+    mode: 0600
+
+- debug:
+    msg: >-
+      You need to configure your own credentials in
+      /home/jenkins/.aws/credentials before running a build, if the host is not
+      an EC2 instance with an IAM Instance Profile.

--- a/ansible/roles/jenkins/templates/aws_config.j2
+++ b/ansible/roles/jenkins/templates/aws_config.j2
@@ -1,0 +1,3 @@
+[default]
+output = json
+region = {{ jenkins_aws_region }}

--- a/ansible/roles/jenkins/templates/etc_default_jenkins.j2
+++ b/ansible/roles/jenkins/templates/etc_default_jenkins.j2
@@ -1,0 +1,77 @@
+# defaults for Jenkins automation server
+
+# pulled in from the init script; makes things easier.
+NAME=jenkins
+
+# location of java
+JAVA=/usr/bin/java
+
+# arguments to pass to java
+
+# Allow graphs etc. to work even when an X server is present
+JAVA_ARGS="-Djava.awt.headless=true"
+
+#JAVA_ARGS="-Xmx256m"
+
+# make jenkins listen on IPv4 address
+#JAVA_ARGS="-Djava.net.preferIPv4Stack=true"
+
+PIDFILE=/var/run/$NAME/$NAME.pid
+
+# user and group to be invoked as (default to jenkins)
+JENKINS_USER=$NAME
+JENKINS_GROUP=$NAME
+
+# location of the jenkins war file
+JENKINS_WAR=/opt/$NAME/$NAME.war
+
+# jenkins home location
+JENKINS_HOME=/opt/$NAME/jenkins_home
+
+# set this to false if you don't want Jenkins to run by itself
+# in this set up, you are expected to provide a servlet container
+# to host jenkins.
+RUN_STANDALONE=true
+
+# log location.  this may be a syslog facility.priority
+JENKINS_LOG=/var/log/$NAME/$NAME.log
+#JENKINS_LOG=daemon.info
+
+# OS LIMITS SETUP
+#   comment this out to observe /etc/security/limits.conf
+#   this is on by default because http://github.com/jenkinsci/jenkins/commit/2fb288474e980d0e7ff9c4a3b768874835a3e92e
+#   reported that Ubuntu's PAM configuration doesn't include pam_limits.so, and as a result the # of file
+#   descriptors are forced to 1024 regardless of /etc/security/limits.conf
+MAXOPENFILES=8192
+
+# set the umask to control permission bits of files that Jenkins creates.
+#   027 makes files read-only for group and inaccessible for others, which some security sensitive users
+#   might consider benefitial, especially if Jenkins runs in a box that's used for multiple purposes.
+#   Beware that 027 permission would interfere with sudo scripts that run on the master (JENKINS-25065.)
+#
+#   Note also that the particularly sensitive part of $JENKINS_HOME (such as credentials) are always
+#   written without 'others' access. So the umask values only affect job configuration, build records,
+#   that sort of things.
+#
+#   If commented out, the value from the OS is inherited,  which is normally 022 (as of Ubuntu 12.04,
+#   by default umask comes from pam_umask(8) and /etc/login.defs
+
+UMASK=027
+
+# port for HTTP connector (default 8080; disable with -1)
+HTTP_PORT=8080
+
+
+# servlet context, important if you want to use apache proxying
+PREFIX=/$NAME
+
+# arguments to pass to jenkins.
+# --javahome=$JAVA_HOME
+# --httpPort=$HTTP_PORT (default 8080; disable with -1)
+# --httpsPort=$HTTP_PORT
+# --argumentsRealm.passwd.$ADMIN_USER=[password]
+# --argumentsRealm.roles.$ADMIN_USER=admin
+# --webroot=~/.jenkins/war
+# --prefix=$PREFIX
+
+JENKINS_ARGS="--webroot=/var/cache/$NAME/war --httpPort=$HTTP_PORT"

--- a/ansible/roles/pss/tasks/deploy.yml
+++ b/ansible/roles/pss/tasks/deploy.yml
@@ -101,6 +101,7 @@
       src={{ github_private_key_path | default("~/.ssh/id_rsa") }}
       dest=/home/pss/git_private_key
       owner=pss group=pss mode=0600
+  when: pss_include_branding
 
 - name: Stop Unicorn (gracefully)
   # Unicorn is stopped completely, and later restarted, because we assume that


### PR DESCRIPTION
Add a `jenkins` role to configure a Jenkins master server.

Add a generalized `pyenv` installer.

Additionally (as a separate commit), add a condition to decide whether to copy the SSH key for deployment of the private assets deployed with the Primary Source Sets application.
