### PR TITLE
Add local roles path to ansible config

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-roles_path = ./roles
+roles_path = ./roles:./local/roles


### PR DESCRIPTION
Add a local roles path to the Ansible configuration file, so that you can have site-specific roles.