### PR TITLE
Forego removal of "thumbp" account in "clean"

### DIFF
--- a/ansible/roles/thumbp/tasks/clean.yml
+++ b/ansible/roles/thumbp/tasks/clean.yml
@@ -4,9 +4,6 @@
   service: name=thumbp state=stopped
   ignore_errors: yes
 
-- name: Remove thumbp user
-  user: name=thumbp state=absent
-
 - name: Remove legacy thumbp home directory
   file: path=/home/thumbp state=absent
 


### PR DESCRIPTION
Get rid of the task that removes the whole `thumbp` account in `clean.yml` in the `thumbp` role. This is not necessary and causes a problem with file permissions upon redeployment.

Tested by redeploying with `-e 'clean_thumbp=yes'` repeatedly in the local VM environment.