### PR TITLE
Update Python tools for Jenkins and Ingestion 3 use cases

### DIFF
--- a/ansible/files/install_python_tools.sh
+++ b/ansible/files/install_python_tools.sh
@@ -12,6 +12,10 @@ if [ ! -d $HOME/.pyenv ]; then
     if [ $? -ne 0 ]; then
         exit 1
     fi
+else
+    cd $HOME/.pyenv
+    git pull
+    cd $HOME
 fi
 
 export PYENV_ROOT="$HOME/.pyenv"

--- a/ansible/roles/jenkins/defaults/main.yml
+++ b/ansible/roles/jenkins/defaults/main.yml
@@ -9,5 +9,7 @@ jenkins_sha256: 34fde424dde0e050738f5ad1e316d54f741c237bd380bd663a07f96147bb1390
 # In the future when we upgrade to Ansible 2+ we can just use the SHA256 hash
 # above because the 'stat' module will be able to do SHA256.
 jenkins_md5: 9e14790b2345bf673abb24224eee4d2c
-jenkins_python_version: 2.7.13
+jenkins_python_versions:
+    - 2.7.13
+    - 3.6.3
 jenkins_aws_region: us-east-1

--- a/ansible/roles/jenkins/tasks/main.yml
+++ b/ansible/roles/jenkins/tasks/main.yml
@@ -117,14 +117,20 @@
 - name: Ensure that pyenv is installed for 'jenkins' account
   # The 'jenkins' user is created above, and we prefer to install Python
   # packages like Ansible with pyenv.
+  # There are Ingestion 1 and Ingestion 3 tools that require different versions
+  # of Python.
   become_user: jenkins
   script: >-
-    ../../../files/install_python_tools.sh {{ jenkins_python_version }}
+    ../../../files/install_python_tools.sh {{ item }}
+  with_items: jenkins_python_versions
+  tags:
+    - python
 
 - name: Ensure that the latest version of the AWS CLI is installed
   become_user: jenkins
   script: >-
-    ../../../files/install_aws_cli.sh {{ jenkins_python_version }}
+    ../../../files/install_aws_cli.sh {{ item }}
+  with_items: jenkins_python_versions
 
 - name: Ensure state of AWS CLI configuration directory
   file:


### PR DESCRIPTION
Update Python installations to support multiple versions.
Necessary because we need 2.7 for running Ansible (in the Jenkins role), but version 3 for running some Ingestion3-related utilities.

See https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1899