### PR TITLE
Improve PSS deployment with local source

### DIFF
--- a/ansible/roles/pss/tasks/deploy.yml
+++ b/ansible/roles/pss/tasks/deploy.yml
@@ -37,21 +37,27 @@
 - file: src=/home/pss/pss-local dest=/home/pss/pss state=link
   when: pss_use_local_source
 
-- name: Update primary-source-sets app configuration files
-  template: >-
-    src="{{ item }}.j2" dest="/home/pss/pss/config/{{ item }}"
-    owner=pss group=pss mode=0640
-  with_items:
-    - database.yml
-    - secrets.yml
-  when: not pss_use_local_source
+- name: Update primary-source-sets app database configuration file
+  template:
+    src: database.yml.j2
+    dest: /home/pss/pss/config/database.yml
+    owner: pss
+    group: pss
+    mode: 0640
+
+- name: Update primary-source-sets app secrets configuration file
+  template:
+    src: secrets.yml.j2
+    dest: /home/pss/pss/config/secrets.yml
+    owner: pss
+    group: pss
+    mode: 0640
 
 - name: Update primary-source-sets app settings
   template: >-
       src=settings.local.yml.j2
       dest=/home/pss/pss/config/settings.local.yml
       owner=pss group=webapp mode=0640
-  when: not pss_use_local_source
 
 - name: Update primary-source-sets unicorn.rb
   template: >-


### PR DESCRIPTION
Improve the PSS deployment using the "local source" option so that it's easier to simulate the production environment with the development VMs.

The old method, copying the configuration files from the developer's source code working copy, was confusing, because they're normally written from the .j2 templates. If you want to use "local source" and also have config files that are similar to what you'd get in production, it's easier to manage that by updating your `group_vars/development` file with the settings you want.