### PR TITLE
Ensure aptitude installation for package upgrades

### DIFF
--- a/ansible/playbooks/package_upgrade.yml
+++ b/ansible/playbooks/package_upgrade.yml
@@ -4,6 +4,11 @@
   hosts: all
   become: yes
   tasks:
+    - name: Ensure state of aptitude utility
+      apt: pkg=aptitude state=present update_cache=yes
+      tags:
+        - packages
+
     - name: Upgrade apt packages
       apt: upgrade=safe update_cache=yes
       tags:


### PR DESCRIPTION
In package_upgrade.yml, assert that aptitude is present, because it's
possible for it not to be in Ubuntu 16. The version of Ansible we still
use requires aptitude and won't fall back to apt-get.