### PR TITLE
Fix incorrect VM box in Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Please install the following tools as documented on their websites:
   for our VMs:
 ```
 $ vagrant box add ubuntu/trusty64
-$ vagrant box add bento/ubuntu-16.04
 ```
 * Add the following entries to your /etc/hosts file or the equivalent for your
   operating system:

--- a/Vagrantfile.dist
+++ b/Vagrantfile.dist
@@ -29,7 +29,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # Elasticsearch (Ubuntu 16.04)
     config.vm.define :es do |es|
-        es.vm.box = "bento/ubuntu-16.04"
+        es.vm.box = "bento/trusty64"
         es.vm.network :private_network, ip: "192.168.50.50"
         es.vm.provider "virtualbox" do |vb|
             vb.memory = 1024


### PR DESCRIPTION
I'm really sorry about this, but I had one of the VMs using the wrong Virtualbox box. I'd been playing around with Ubuntu 16 but ended up going back to 14 for the Elasticsearch box in my local `Vagrantfile`, and didn't make the corresponding fix to `Vagrantfile.dist`.

