### PR TITLE
Added switch for hiding reports link.

### DIFF
--- a/ansible/roles/api/templates/dpla.yml.j2
+++ b/ansible/roles/api/templates/dpla.yml.j2
@@ -97,3 +97,7 @@ field_boosts:
 
 api:
   email_from_address: {{ api_key_email_from }}
+
+{% if hide_reports | default(false) %}
+hide_reports: true
+{% endif %}

--- a/ansible/roles/api/templates/dpla.yml.j2
+++ b/ansible/roles/api/templates/dpla.yml.j2
@@ -98,6 +98,6 @@ field_boosts:
 api:
   email_from_address: {{ api_key_email_from }}
 
-{% if hide_reports | default(false) %}
+{% if api_hide_reports | default(false) %}
 hide_reports: true
 {% endif %}


### PR DESCRIPTION
Cqai3 boxes shouldn't have the reports link because they don't work.
There's a feature in the platform-cqa app that turns them off. 
Here's the deployment side of it.