### PR TITLE
Fix hosts file w resolvconf

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -40,6 +40,8 @@
     owner: root
     group: root
   notify: update resolv.conf
+  tags:
+    - networking
 
 - meta: flush_handlers
 

--- a/ansible/roles/common/templates/hosts.j2
+++ b/ansible/roles/common/templates/hosts.j2
@@ -8,14 +8,18 @@ ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 
 {% if all_in_one_hosts | default(false) %}
+
 {{ hostvars[inventory_hostname][internal_network_interface].ipv4.address }}  {{ inventory_hostname | replace('_', '-')}}
-{% else %}
+
+{% elif resolver_domains|length == 0 %}
+
 {% for h in groups[all_group_name] %}
 {# Hostnames should not have underscores, but dynamic inventories (particularly,
    EC2) can have names with underscores. They have to be converted to use
    hyphens. #}
 {{ hostvars[h][internal_network_interface]['ipv4']['address'] }}	{{ h | replace('_', '-')}}
 {% endfor %}
+
 {% endif %}
 
 {% if level is defined and level == 'development' %}

--- a/ansible/roles/common/templates/hosts.j2
+++ b/ansible/roles/common/templates/hosts.j2
@@ -6,6 +6,7 @@ fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
+ff02::3 ip6-allhosts
 
 {% if all_in_one_hosts | default(false) %}
 


### PR DESCRIPTION
These commits fix an annoyance with running the `common` role.

The `Update hosts file` task in that role has been the most error-prone task in the whole `automation` project for a long time. You couldn't run the `common` role on just one host without commenting that task out. There were also frequent errors due to different EC2 instance types having different ethernet interface names.

This changeset circumvents these problems by using the name resolver in an environment where the hosts are on a network with DNS for all of the hosts. There's no more need to interrogate all of the hosts in order to find their IP addresses and add them to `/etc/hosts`.